### PR TITLE
add development mode to chs-delta-api

### DIFF
--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -1,0 +1,16 @@
+custom_build(
+  ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/chs-delta-api',
+  command = 'DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF .',
+  deps = [
+    './',
+  ],
+  ignore = [
+    'LICENSE',
+    'Makefile',
+    'Readme',
+    '.gitignore',
+    '.dockerignore',
+    'version',
+    'start'
+  ]
+)


### PR DESCRIPTION
Add Tiltfile.dev for easier development.

Allows auto reloading / building of application on file changes.

Resolves:
DSND-26 [https://companieshouse.atlassian.net/browse/DSND-26]