### PR TITLE
Add Kafka broker address to config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CHS_ENV_HOME ?= $(HOME)/.chs_env
 TESTS        ?= ./...
 
 bin          := chs-delta-api
-chs_envs     := $(CHS_ENV_HOME)/global_env $(CHS_ENV_HOME)/chs-delta-api/env
+chs_envs     := $(CHS_ENV_HOME)/global_env #$(CHS_ENV_HOME)/chs-delta-api/env
 source_env   := for chs_env in $(chs_envs); do test -f $$chs_env && . $$chs_env; done
 xunit_output := test.xml
 lint_output  := lint.txt

--- a/config/config.go
+++ b/config/config.go
@@ -12,8 +12,9 @@ var mtx sync.Mutex
 
 // Config defines the configuration options for this service.
 type Config struct {
-	BindAddr string `env:"BIND_ADDR" flag:"bind-addr" flagDesc:"Bind address"`
-	ChsUrl   string `env:"CHS_URL"   flag:"chs-url"   flagDesc:"CHS URL"`
+	BindAddr   string   `env:"BIND_ADDR" flag:"bind-addr" flagDesc:"Bind address"`
+	BrokerAddr []string `env:"KAFKA_BROKER_ADDR" flag:"broker-addr" flagDesc:"Kafka broker address"`
+	ChsUrl     string   `env:"CHS_URL" flag:"chs-url" flagDesc:"CHS URL"`
 }
 
 // Get returns a pointer to a Config instance populated with values from environment or command-line flags

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,6 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 h1:WN9BUFbdyOsSH/XohnWpXOlq9NBD5sGAB2FciQMUEe8=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/smartystreets/goconvey v1.6.3 h1:QdmJJYlDQhMDFrFP8IvVnx66D8mCbaQM4TsxKf7BXzo=
-github.com/smartystreets/goconvey v1.6.3/go.mod h1:XDJAKZRPZ1CvBcN2aX5YOUTYGHki24fSF0Iv48Ibg0s=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/start.sh
+++ b/start.sh
@@ -21,10 +21,11 @@ else
     echo "Downloading environment from: ${CONFIG_URL}/${ENVIRONMENT}/${APP_NAME}"
     wget -O "${APP_DIR}/private_env" "${CONFIG_URL}/${ENVIRONMENT}/private_env"
     wget -O "${APP_DIR}/global_env" "${CONFIG_URL}/${ENVIRONMENT}/global_env"
-    wget -O "${APP_DIR}/app_env" "${CONFIG_URL}/${ENVIRONMENT}/${APP_NAME}/env"
+    # NOTE: Leave commented until DSND-29 has been completed.
+    # wget -O "${APP_DIR}/app_env" "${CONFIG_URL}/${ENVIRONMENT}/${APP_NAME}/env"
     source "${APP_DIR}/private_env"
     source "${APP_DIR}/global_env"
-    source "${APP_DIR}/app_env"
+    #source "${APP_DIR}/app_env"
 fi
 
 # Read brokers from environment and split on comma

--- a/start.sh
+++ b/start.sh
@@ -7,7 +7,7 @@ APP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 if [[ -z "${MESOS_SLAVE_PID}" ]]; then
     source ~/.chs_env/private_env
     source ~/.chs_env/global_env
-    source ~/.chs_env/chs-delta-api/env
+    #source ~/.chs_env/chs-delta-api/env
 
     PORT="${CHS_DELTA_API_PORT}"
 else


### PR DESCRIPTION
Adding broker address field to config
so that the start script can successfully
load them into the application.

Remove reference to individual config per env
until we need it. For now we will rely on global env.

**Resolves**
DSND-22