### PR TITLE
Make group internal as per PR comments

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,6 +1,6 @@
 ---
 app_name: chs-delta-api
-group: api
+group: internalapi
 weight: 900
 routes:
-  1: ^/chs-delta-api.*
+  1: ^/delta.*


### PR DESCRIPTION
Addressing PR comments, we've changed the group on routes.yaml to be internalapi