### PR TITLE
Fixes an issue where trying to hit route endpoints wasn't working.

### DIFF
--- a/handlers/register.go
+++ b/handlers/register.go
@@ -10,7 +10,7 @@ import (
 
 // Register defines the endpoints for the API
 func Register(mainRouter *mux.Router) {
-	mainRouter.HandleFunc("/healthcheck", healthCheck).Methods(http.MethodGet).Name("healthcheck")
+	mainRouter.HandleFunc("/delta/healthcheck", healthCheck).Methods(http.MethodGet)
 	mainRouter.Use(log.Handler)
 }
 

--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ func main() {
 
 	// Create router
 	mainRouter := mux.NewRouter()
-
 	handlers.Register(mainRouter)
 
 	log.Info("Starting " + namespace)


### PR DESCRIPTION
In docker-chs-dev we have a docker compose which looks for /delta
in a request and routes it towards our container. We forgot to still
add /delta to our route which meant the endpoint wasn't being hit.

By adding /delta we ensure we hit the endpoint and functionality is
now working as expected.

Removed unwanted space between calls in main.