### PR TITLE
Fix hadolint Docker linter issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.16-alpine-builder
-FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.16-alpine-runtime
-COPY --from=0 /build/apispec ./apispec
+FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.16-alpine-builder AS golang-builder
+FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.16-alpine-runtime AS golang-runtime
+WORKDIR /app
+COPY --from=golang-builder /build/apispec ./apispec
 CMD ["-bind-addr=:5010"]
 EXPOSE 5010
 


### PR DESCRIPTION
hadonlint complained that the copy uses a numbered target, not a nmae.
 Fixed by adding AS labels to the FROM lines
hadolint complained that the COPY instruction was not preceded by a
WORKDIR instruction.
Fixed by explicitly stating the WORKDIR first.