### PR TITLE
Add documentation for unit testing open api shcemas

### DIFF
--- a/docs/unit-testing-a-new-schema.md
+++ b/docs/unit-testing-a-new-schema.md
@@ -22,8 +22,8 @@ All unit tests will follow the same structure:
 1. Load in the example request body from a text file using the `common.ReadRequestBody()` function
 2. Create and populate a test httpRequest 
     1. Set its target to your delta's endpoint
-    2. Set it's body to that previously loaded in step 1
-    3. Set the request's headers using the provided `SetHeaders` function in `/validation/schema_testing/common/schemaUnitTesting.go`
+    2. Set its body to that previously loaded in step 1
+    3. Set its headers using the provided `SetHeaders` function in `/validation/schema_testing/common/schemaUnitTesting.go`
 3. Create an instance of the CHValidator and call its `ValidateRequestAgainstOpenApiSpec` method, passing it your example
 `request`, `openAPI spec location` and a dummy `contextId`.
 4. The final step of every unit test is to read in your expected response body using the `common.ReadRequstBody()` function

--- a/docs/unit-testing-a-new-schema.md
+++ b/docs/unit-testing-a-new-schema.md
@@ -1,0 +1,69 @@
+# Unit testing a new schema
+
+## Overview
+As the chs-delta-api uses a 3rd party library (See `/docs` directory for documentation on the kin-openAPI3 library) to 
+validate its requests, there is no way to directly unit test the code. This document will guide you through creating 
+unit tests which assert that your open API schema is working correctly.
+
+## 1. Where to add your unit tests
+Move into the `/validation/schema_testing` directory and create a new directory to contain your unit tests. Inside of your
+new directory, create a set `/request_bodies` and `/response_bodies` directories. These will contain your sample request 
+and response bodies used to unit test the schema.
+
+Finally, create a new Go file ending in `_test` (e.g. `exampleDeltaSchema_test.go`). This file will contain the unit 
+tests used to test the schema.
+
+## 2. Unit test structure
+We elected to structure the open API schema unit tests using a `Karate API Scenario` layout. Each unit test will have a 
+`Given`, `When`, `Then` stage and will use sample request bodies and response bodies to test the schema.
+
+All unit tests will follow the same structure:
+
+1. Load in the wanted request body from a text file using the `common.ReadRequestBody()` function
+2. Create a test httpRequest and set its target to your delta's endpoint, and it's request body to the previously read in
+request body, and finally set the requests headers.
+3. Create an instance of the CHValidator and call it's `ValidateRequestAgainstOpenApiSpec` method, passing it your example
+`request`, `open API spec location` and a dummy `contextId`.
+4. The final step of every unit test is to read in your expected response body using the `common.ReadRequstBody()` function
+and using the `common.CompareActualToExpected(actualResponseBody, expectedResponseBody)` to assert that your expected response
+matches the actual response.
+
+Example structure of a unit test
+```go
+func TestSchemaExample(t *testing.T) {
+
+	Convey("Given I want to test the example-delta API schema", t, func() {
+
+		exampleRequestBody := common.ReadRequestBody(exampleRequestBodyLocation)
+
+		r := httptest.NewRequest("POST", exampleEndpoint, bytes.NewBuffer(exampleRequestBody))
+		r = common.SetHeaders(r)
+
+		Convey("When I call to validate the request body, providing a request", func() {
+
+			chv := validation.NewCHValidator()
+
+			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
+
+			Convey("Then I am given a validation response", func() {
+				exampleErrorResponseBody := common.ReadRequestBody(exampleErrorResponseBodyLocation)
+				match := common.CompareActualToExpected(validationErrs, exampleErrorResponseBody)
+                
+				So(validationErrs, ShouldNotBeNil)
+				So(match, ShouldEqual, true)
+			})
+		})
+	})
+}
+```
+
+## 3. What to cover and what not to cover in unit tests
+The following areas of validation need to be covered by unit tests:
+
+- Validate requests return no errors
+- Mandatory / Required
+- Type assertion (`int` only allows `int`, `string` only allows `string`)
+
+The following areas of validation should not be covered by unit tests:
+
+- Range validation (as it is better covered by Karate)

--- a/docs/unit-testing-a-new-schema.md
+++ b/docs/unit-testing-a-new-schema.md
@@ -3,7 +3,7 @@
 ## Overview
 As the chs-delta-api uses a 3rd party library (See `/docs` directory for documentation on the kin-openAPI3 library) to 
 validate its requests, there is no way to directly unit test the code. This document will guide you through creating 
-unit tests which assert that your open API schema is working correctly.
+unit tests which assert that your openAPI schema is working correctly.
 
 ## 1. Where to add your unit tests
 Move into the `/validation/schema_testing` directory and create a new directory to contain your unit tests. Inside of your
@@ -14,7 +14,7 @@ Finally, create a new Go file ending in `_test` (e.g. `exampleDeltaSchema_test.g
 tests used to test the schema.
 
 ## 2. Unit test structure
-We elected to structure the open API schema unit tests using a `Karate API Scenario` layout. Each unit test will have a 
+We elected to structure the openAPI schema unit tests using a `Karate API Scenario` layout. Each unit test will have a 
 `Given`, `When`, `Then` stage and will use sample request bodies and response bodies to test the schema.
 
 All unit tests will follow the same structure:
@@ -23,7 +23,7 @@ All unit tests will follow the same structure:
 2. Create a test httpRequest and set its target to your delta's endpoint, and its request's body to the previously read in
 request's body, and finally set the requests headers.
 3. Create an instance of the CHValidator and call its `ValidateRequestAgainstOpenApiSpec` method, passing it your example
-`request`, `open API spec location` and a dummy `contextId`.
+`request`, `openAPI spec location` and a dummy `contextId`.
 4. The final step of every unit test is to read in your expected response body using the `common.ReadRequstBody()` function
 and using the `common.CompareActualToExpected(actualResponseBody, expectedResponseBody)` to assert that your expected response
 matches the actual response.

--- a/docs/unit-testing-a-new-schema.md
+++ b/docs/unit-testing-a-new-schema.md
@@ -19,35 +19,35 @@ We elected to structure the open API schema unit tests using a `Karate API Scena
 
 All unit tests will follow the same structure:
 
-1. Load in the wanted request body from a text file using the `common.ReadRequestBody()` function
-2. Create a test httpRequest and set its target to your delta's endpoint, and it's request body to the previously read in
-request body, and finally set the requests headers.
-3. Create an instance of the CHValidator and call it's `ValidateRequestAgainstOpenApiSpec` method, passing it your example
+1. Load in the example request body from a text file using the `common.ReadRequestBody()` function
+2. Create a test httpRequest and set its target to your delta's endpoint, and its request's body to the previously read in
+request's body, and finally set the requests headers.
+3. Create an instance of the CHValidator and call its `ValidateRequestAgainstOpenApiSpec` method, passing it your example
 `request`, `open API spec location` and a dummy `contextId`.
 4. The final step of every unit test is to read in your expected response body using the `common.ReadRequstBody()` function
 and using the `common.CompareActualToExpected(actualResponseBody, expectedResponseBody)` to assert that your expected response
 matches the actual response.
 
-Example structure of a unit test
+Example structure of a unit test (Mandatory elements missing unit test)
 ```go
-func TestSchemaExample(t *testing.T) {
+func TestSchemaExampleMissingMandatory(t *testing.T) {
 
-	Convey("Given I want to test the example-delta API schema", t, func() {
+	Convey("Given I want to test that missing mandatory fields in the exampleDelta are correctly reported", t, func() {
 
-		exampleRequestBody := common.ReadRequestBody(exampleRequestBodyLocation)
+		mandatoryMissingRequestBody := common.ReadRequestBody(mandatoryMissingRequestBodyLocation)
 
-		r := httptest.NewRequest("POST", exampleEndpoint, bytes.NewBuffer(exampleRequestBody))
+		r := httptest.NewRequest("POST", exampleEndpoint, bytes.NewBuffer(mandatoryMissingRequestBody))
 		r = common.SetHeaders(r)
 
-		Convey("When I call to validate the request body, providing a request", func() {
+		Convey("When I call to validate the request body, providing a request which is missing mandatory fields", func() {
 
 			chv := validation.NewCHValidator()
 
-			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
+			actualResponseBody, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
 
-			Convey("Then I am given a validation response", func() {
-				exampleErrorResponseBody := common.ReadRequestBody(exampleErrorResponseBodyLocation)
-				match := common.CompareActualToExpected(validationErrs, exampleErrorResponseBody)
+			Convey("Then I am given a validation response stating that mandatory fields are missing", func() {
+				expectedResponseBody := common.ReadRequestBody(mandatoryMissingErrorResponseBodyLocation)
+				match := common.CompareActualToExpected(actualResponseBody, expectedResponseBody)
                 
 				So(validationErrs, ShouldNotBeNil)
 				So(match, ShouldEqual, true)

--- a/docs/unit-testing-a-new-schema.md
+++ b/docs/unit-testing-a-new-schema.md
@@ -20,8 +20,10 @@ We elected to structure the openAPI schema unit tests using a `Karate API Scenar
 All unit tests will follow the same structure:
 
 1. Load in the example request body from a text file using the `common.ReadRequestBody()` function
-2. Create a test httpRequest and set its target to your delta's endpoint, and its request's body to the previously read in
-request's body, and finally set the requests headers.
+2. Create and populate a test httpRequest 
+    1. Set its target to your delta's endpoint
+    2. Set it's body to that previously loaded in step 1
+    3. Set the request's headers using the provided `SetHeaders` function in `/validation/schema_testing/common/schemaUnitTesting.go`
 3. Create an instance of the CHValidator and call its `ValidateRequestAgainstOpenApiSpec` method, passing it your example
 `request`, `openAPI spec location` and a dummy `contextId`.
 4. The final step of every unit test is to read in your expected response body using the `common.ReadRequstBody()` function

--- a/validation/schema_testing/common/schemaUnitTesting.go
+++ b/validation/schema_testing/common/schemaUnitTesting.go
@@ -1,0 +1,85 @@
+// common contains common functions which can be used when unit testing schemas to make them more compact and easy to implement.
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/companieshouse/chs-delta-api/models"
+	"net/http"
+	"os"
+)
+
+const (
+	xRequestId      = "X-Request-Id"
+	contentType     = "Content-Type"
+	applicationJson = "application/json"
+	contextId       = "contextId"
+)
+
+// SetHeaders sets the required headers for the unit testing schemas to correctly function.
+// We require a contextId to be set in the Header of the request as it will be later pulled and used as a contextId.
+// We require a contentType to be set (application/json) for the kin-openAPI library to validate the request.
+func SetHeaders(r *http.Request) *http.Request {
+	r.Header.Set(xRequestId, contextId)
+	r.Header.Set(contentType, applicationJson)
+
+	return r
+}
+
+// ReadRequestBody takes a file location in the format of a string relative path and reads in the contents from the file,
+// removing any extra tabs, spaces and special characters using json.Compact(). Returns a []byte version of the formatted file read in.
+func ReadRequestBody(fl string) []byte {
+
+	// Read in contents and covert it to a string for further processing.
+	raw, _ := os.ReadFile(fl)
+
+	buffer := new(bytes.Buffer)
+	_ = json.Compact(buffer, raw)
+
+	raw = buffer.Bytes()
+	// Convert back to an []byte and return.
+	return raw
+}
+
+// CompareActualToExpected takes actual and expected json (as byte arrays) and compares them to see if they match. Ordering of response
+// isn't always guaranteed when calling the kin-openAPI validator so using this function allows you to match the response
+// the library gives you with an expected response without worrying about ordering.
+func CompareActualToExpected(actual, expected []byte) bool {
+
+	// Define 2 model CHError arrays to hold actual and expected responses.
+	var actualErrArr *[]models.CHError
+	var expectedErrArr *[]models.CHError
+
+	// Convert responses to JSON object arrays.
+	_ = json.Unmarshal(actual, &actualErrArr)
+	_ = json.Unmarshal(expected, &expectedErrArr)
+
+	// If the arrays don't match in length, they can't be a complete match so return false.
+	if len(*actualErrArr) != len(*expectedErrArr) {
+		return false
+	}
+
+	// create a map of CHError.Location (string) -> int to compare if both arrays are completely equal.
+	diff := make(map[string]int, len(*expectedErrArr))
+
+	// Range over the expected response array and add them to the newly created map.
+	for _, ee := range *expectedErrArr {
+		// 0 value for int is 0, so just increment a counter for the string
+		diff[ee.Location]++
+	}
+
+	// Finally range over the actual response array errors and check that they exist in the expected errors map.
+	for _, ae := range *actualErrArr {
+		// If the error is not in diff bail out early as they can't be a match.
+		if _, ok := diff[ae.Location]; !ok {
+			return false
+		}
+		diff[ae.Location] -= 1
+		if diff[ae.Location] == 0 {
+			delete(diff, ae.Location)
+		}
+	}
+
+	// Return if length of remaining map values is equal to 0. If it is, we have a match.
+	return len(diff) == 0
+}

--- a/validation/schema_testing/officers/officerDeltaSchema_test.go
+++ b/validation/schema_testing/officers/officerDeltaSchema_test.go
@@ -2,13 +2,10 @@ package officers
 
 import (
 	"bytes"
-	"encoding/json"
-	"github.com/companieshouse/chs-delta-api/models"
 	"github.com/companieshouse/chs-delta-api/validation"
+	"github.com/companieshouse/chs-delta-api/validation/schema_testing/common"
 	. "github.com/smartystreets/goconvey/convey"
-	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 )
 
@@ -27,11 +24,7 @@ const (
 
 	officersEndpoint = "/delta/officers"
 	apiSpecLocation  = "../../../apispec/api-spec.yml"
-
-	contextId       = "contextId"
-	xRequestId      = "X-Request-Id"
-	contentType     = "Content-Type"
-	applicationJson = "application/json"
+	contextId        = "contextId"
 )
 
 // TestOfficerDeltaSchemaNoErrors asserts that when a valid request body is given which matches the schema, then no
@@ -40,10 +33,10 @@ func TestOfficerDeltaSchemaNoErrors(t *testing.T) {
 
 	Convey("Given I want to test the officers-delta API schema", t, func() {
 
-		okRequestBody := readRequestBody(okRequestBodyLocation)
+		okRequestBody := common.ReadRequestBody(okRequestBodyLocation)
 
 		r := httptest.NewRequest("POST", officersEndpoint, bytes.NewBuffer(okRequestBody))
-		r = setHeaders(r)
+		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing a valid request", func() {
 
@@ -64,10 +57,10 @@ func TestOfficerDeltaSchemaTypeErrors(t *testing.T) {
 
 	Convey("Given I want to test the officers-delta API schema for type assertions", t, func() {
 
-		typeErrorRequestBody := readRequestBody(typeErrorRequestBodyLocation)
+		typeErrorRequestBody := common.ReadRequestBody(typeErrorRequestBodyLocation)
 
 		r := httptest.NewRequest("POST", officersEndpoint, bytes.NewBuffer(typeErrorRequestBody))
-		r = setHeaders(r)
+		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing an valid request with type errors", func() {
 
@@ -76,8 +69,8 @@ func TestOfficerDeltaSchemaTypeErrors(t *testing.T) {
 			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
 
 			Convey("Then I am given an errors array response as validation errors have been found", func() {
-				typeErrorResponseBody := readRequestBody(typeErrorResponseBodyLocation)
-				match := compareActualToExpected(validationErrs, typeErrorResponseBody)
+				typeErrorResponseBody := common.ReadRequestBody(typeErrorResponseBodyLocation)
+				match := common.CompareActualToExpected(validationErrs, typeErrorResponseBody)
 
 				So(validationErrs, ShouldNotBeNil)
 				So(match, ShouldEqual, true)
@@ -92,10 +85,10 @@ func TestOfficerDeltaSchemaRequiredErrors(t *testing.T) {
 
 	Convey("Given I want to test the officers-delta API schema to assert mandatory validation is working correctly", t, func() {
 
-		mandatoryErrorsRequestBody := readRequestBody(requiredErrorRequestBodyLocation)
+		mandatoryErrorsRequestBody := common.ReadRequestBody(requiredErrorRequestBodyLocation)
 
 		r := httptest.NewRequest("POST", officersEndpoint, bytes.NewBuffer(mandatoryErrorsRequestBody))
-		r = setHeaders(r)
+		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing an valid request with missing mandatory values", func() {
 
@@ -104,8 +97,8 @@ func TestOfficerDeltaSchemaRequiredErrors(t *testing.T) {
 			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
 
 			Convey("Then I am given an errors array response as validation errors have been found", func() {
-				mandatoryErrorsResponseBody := readRequestBody(requiredErrorResponseBodyLocation)
-				match := compareActualToExpected(validationErrs, mandatoryErrorsResponseBody)
+				mandatoryErrorsResponseBody := common.ReadRequestBody(requiredErrorResponseBodyLocation)
+				match := common.CompareActualToExpected(validationErrs, mandatoryErrorsResponseBody)
 
 				So(validationErrs, ShouldNotBeNil)
 				So(match, ShouldEqual, true)
@@ -120,10 +113,10 @@ func TestOfficerDeltaSchemaEnumErrors(t *testing.T) {
 
 	Convey("Given I want to test the officers-delta API schema to assert ENUM validation is working correctly", t, func() {
 
-		enumErrorsRequestBody := readRequestBody(enumErrorRequestBodyLocation)
+		enumErrorsRequestBody := common.ReadRequestBody(enumErrorRequestBodyLocation)
 
 		r := httptest.NewRequest("POST", officersEndpoint, bytes.NewBuffer(enumErrorsRequestBody))
-		r = setHeaders(r)
+		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing an valid request with incorrect ENUM values", func() {
 
@@ -132,8 +125,8 @@ func TestOfficerDeltaSchemaEnumErrors(t *testing.T) {
 			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
 
 			Convey("Then I am given an errors array response as validation errors have been found", func() {
-				enumErrorsResponseBody := readRequestBody(enumErrorResponseBodyLocation)
-				match := compareActualToExpected(validationErrs, enumErrorsResponseBody)
+				enumErrorsResponseBody := common.ReadRequestBody(enumErrorResponseBodyLocation)
+				match := common.CompareActualToExpected(validationErrs, enumErrorsResponseBody)
 
 				So(validationErrs, ShouldNotBeNil)
 				So(match, ShouldEqual, true)
@@ -149,7 +142,7 @@ func TestOfficerDeltaSchemaNoRequestBodyError(t *testing.T) {
 	Convey("Given I want to test the officers-delta API schema to assert validation is working correctly", t, func() {
 
 		r := httptest.NewRequest("POST", officersEndpoint, bytes.NewBuffer(nil))
-		r = setHeaders(r)
+		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing an empty request body", func() {
 
@@ -158,77 +151,12 @@ func TestOfficerDeltaSchemaNoRequestBodyError(t *testing.T) {
 			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
 
 			Convey("Then I am given an error saying no request body provided", func() {
-				noRequestBodyErrorsResponseBody := readRequestBody(noRequestBodyErrorResponseBodyLocation)
-				match := compareActualToExpected(validationErrs, noRequestBodyErrorsResponseBody)
+				noRequestBodyErrorsResponseBody := common.ReadRequestBody(noRequestBodyErrorResponseBodyLocation)
+				match := common.CompareActualToExpected(validationErrs, noRequestBodyErrorsResponseBody)
 
 				So(validationErrs, ShouldNotBeNil)
 				So(match, ShouldEqual, true)
 			})
 		})
 	})
-}
-
-// setHeaders sets the required headers for the unit testing to correctly function.
-func setHeaders(r *http.Request) *http.Request {
-	r.Header.Set(xRequestId, contextId)
-	r.Header.Set(contentType, applicationJson)
-
-	return r
-}
-
-// readRequestBody takes a file location in the format of a string relative path and reads in the contents from the file,
-// removing any extra tabs, spaces and special characters using json.Compact. Returns a []byte version of the formatted file read in.
-func readRequestBody(fl string) []byte {
-
-	// Read in contents and covert it to a string for further processing.
-	raw, _ := os.ReadFile(fl)
-
-	buffer := new(bytes.Buffer)
-	_ = json.Compact(buffer, raw)
-
-	raw = buffer.Bytes()
-	// Convert back to an []byte and return.
-	return raw
-}
-
-// compareActualToExpected takes actual and expected json (as byte arrays) and compares them to see if they match. Ordering of response
-// isn't always guaranteed so using this function to match them without having to worry about the order changing.
-func compareActualToExpected(actual, expected []byte) bool {
-
-	// Define 2 model CHError arrays to hold actual and expected responses.
-	var actualErrArr *[]models.CHError
-	var expectedErrArr *[]models.CHError
-
-	// Convert responses to JSON object arrays.
-	_ = json.Unmarshal(actual, &actualErrArr)
-	_ = json.Unmarshal(expected, &expectedErrArr)
-
-	// If the arrays don't match in length, they can't be a complete match so return false.
-	if len(*actualErrArr) != len(*expectedErrArr) {
-		return false
-	}
-
-	// create a map of CHError.Location (string) -> int to compare if both arrays are completely equal.
-	diff := make(map[string]int, len(*expectedErrArr))
-
-	// Range over the expected response array and add them to the newly created map.
-	for _, ee := range *expectedErrArr {
-		// 0 value for int is 0, so just increment a counter for the string
-		diff[ee.Location]++
-	}
-
-	// Finally range over the actual response array errors and check that they exist in the expected errors map.
-	for _, ae := range *actualErrArr {
-		// If the error is not in diff bail out early as they can't be a match.
-		if _, ok := diff[ae.Location]; !ok {
-			return false
-		}
-		diff[ae.Location] -= 1
-		if diff[ae.Location] == 0 {
-			delete(diff, ae.Location)
-		}
-	}
-
-	// Return if length of remaining map values is equal to 0. If it is, we have a match.
-	return len(diff) == 0
 }


### PR DESCRIPTION
A document has been added to the /docs directory to help
guide developers through unit testing their schema once they have
added it to the chs-delta-api.

A change to pull common unit testing code into a common folder has been made in this PR as well. By 
moving the code into a common shared file, future developers can make use of the functions provided to significantly 
lower the amount of code needed to test their schemas.