### PR TITLE
Add validate endpoint for officers

### DIFF
--- a/apispec/api-spec.yml
+++ b/apispec/api-spec.yml
@@ -7,6 +7,8 @@ info:
 paths:
   /delta/officers:
     $ref: 'officer-delta-spec.yml'
+  /delta/officers/validate:
+    $ref: 'officer-delta-spec.yml'
 
 components:
   securitySchemes:

--- a/handlers/common/handlersTestUtil.go
+++ b/handlers/common/handlersTestUtil.go
@@ -1,0 +1,21 @@
+package common
+
+import "os"
+
+const (
+	TestRequestBody = `{"dummy" : "request"}`
+	TestContextId   = "contextId"
+	PostRestMethod = "POST"
+)
+
+func InitEnv() {
+	_ = os.Setenv("BIND_ADDR", "bind_addr")
+	_ = os.Setenv("KAFKA_BROKER_ADDR", "kafka_broker_addr,kafka_broker_addr")
+	_ = os.Setenv("SCHEMA_REGISTRY_URL", "schema_registry_url")
+	_ = os.Setenv("OFFICER_DELTA_TOPIC", "officer_delta_topic")
+	_ = os.Setenv("OPEN_API_SPEC", "open_api_spec")
+}
+
+func DestroyEnv() {
+	os.Clearenv()
+}

--- a/handlers/deltaValidationHandler.go
+++ b/handlers/deltaValidationHandler.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"fmt"
+	"github.com/companieshouse/chs-delta-api/config"
+	"github.com/companieshouse/chs-delta-api/helpers"
+	"github.com/companieshouse/chs-delta-api/validation"
+	"github.com/companieshouse/chs.go/log"
+	"net/http"
+)
+
+// DeltaValidationHandler offers a handler by which to publish an office-delta onto the officer-delta kafka topic.
+type DeltaValidationHandler struct {
+	h    helpers.Helper
+	chv  validation.CHValidator
+	cfg  *config.Config
+}
+
+// NewDeltaValidationHandler returns an DeltaValidatorHandler.
+func NewDeltaValidationHandler(h helpers.Helper, chv validation.CHValidator, cfg *config.Config) *DeltaValidationHandler {
+	return &DeltaValidationHandler{h: h, chv: chv, cfg: cfg}
+}
+
+// ServeHTTP accepts an incoming OfficerDelta request via a POST method, validates it
+// and then passes it to a Kafka service for further processing along with an officers-delta topic. If errors are
+// encountered then they will be returned via the ResponseWriter.
+func (kp *DeltaValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	contextId := kp.h.GetRequestIdFromHeader(r)
+
+	log.InfoC(contextId, fmt.Sprintf("Using the open api spec: "), log.Data{config.OpenApiSpecKey: kp.cfg.OpenApiSpec})
+
+	// Validate against the open API 3 spec before progressing any further.
+	errValidation, err := kp.chv.ValidateRequestAgainstOpenApiSpec(r, kp.cfg.OpenApiSpec, contextId)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.ErrorC(contextId, err, log.Data{config.MessageKey: "error occurred while trying to validate request"})
+		return
+	} else if errValidation != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_, err = w.Write(errValidation)
+		if err != nil {
+			log.ErrorC(contextId, err, log.Data{config.MessageKey: "error occurred while trying to write response"})
+		}
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/handlers/deltaValidationHandler_test.go
+++ b/handlers/deltaValidationHandler_test.go
@@ -1,0 +1,163 @@
+package handlers
+
+import (
+	"bytes"
+	"errors"
+	"github.com/companieshouse/chs-delta-api/config"
+	"github.com/companieshouse/chs-delta-api/handlers/common"
+	hMocks "github.com/companieshouse/chs-delta-api/helpers/mocks"
+	chvMocks "github.com/companieshouse/chs-delta-api/validation/mocks"
+	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	officersValidateEndpoint = "/delta/officers/validate"
+)
+
+// TestNewDeltaValidationHandler asserts that the constructor for the DeltaValidationHandler returns a fully configured handler.
+func TestNewDeltaValidationHandler(t *testing.T) {
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	Convey("When I call the constructor, then it returns me a valid DeltaValidationHandler", t, func() {
+
+		h := hMocks.NewMockHelper(mockCtrl)
+		chv := chvMocks.NewMockCHValidator(mockCtrl)
+
+		config.CallValidateConfig = func(cfg *config.Config) error {
+			return nil
+		}
+		cfg, _ := config.Get()
+
+		deltaValidationHandler := NewDeltaValidationHandler(h, chv, cfg)
+
+		So(deltaValidationHandler, ShouldNotBeNil)
+
+		So(deltaValidationHandler.chv, ShouldNotBeNil)
+		So(deltaValidationHandler.chv, ShouldEqual, chv)
+
+		So(deltaValidationHandler.h, ShouldNotBeNil)
+		So(deltaValidationHandler.h, ShouldEqual, h)
+	})
+}
+
+// TestDeltaValidationHandlerErrorsCallingValidation asserts that the DeltaValidationHandler returns an internal error status when
+// call to validate the request fails (internal failure such as failure to open schema, not a user validation failure).
+func TestDeltaValidationHandlerErrorsCallingValidation(t *testing.T) {
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	Convey("Given a HTTP POST request via the officer delta validate endpoint", t, func() {
+
+		req := httptest.NewRequest(common.PostRestMethod, officersValidateEndpoint, bytes.NewBuffer([]byte(common.TestRequestBody)))
+		resp := httptest.NewRecorder()
+
+		Convey("When the request is handled by the router, but the kafka service fails to send", func() {
+
+			h := hMocks.NewMockHelper(mockCtrl)
+			chv := chvMocks.NewMockCHValidator(mockCtrl)
+
+			common.InitEnv()
+			config.CallValidateConfig = func(cfg *config.Config) error {
+				return nil
+			}
+			cfg, _ := config.Get()
+
+			handler := NewDeltaValidationHandler(h, chv, cfg)
+
+			h.EXPECT().GetRequestIdFromHeader(req).Return(common.TestContextId)
+			chv.EXPECT().ValidateRequestAgainstOpenApiSpec(req, handler.cfg.OpenApiSpec, common.TestContextId).Return(nil, errors.New("error"))
+
+			handler.ServeHTTP(resp, req)
+
+			Convey("Then the response should be 500 and an error returned", func() {
+				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+
+			common.DestroyEnv()
+		})
+	})
+}
+
+// TestDeltaValidationHandlerSuccessfulValidation asserts that the DeltaValidationHandler returns an ok status when validation passes
+func TestDeltaValidationHandlerSuccessfulValidation(t *testing.T) {
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	Convey("Given a HTTP POST request via the officer delta validate endpoint", t, func() {
+
+		req := httptest.NewRequest(common.PostRestMethod, officersValidateEndpoint, bytes.NewBuffer([]byte(common.TestRequestBody)))
+		resp := httptest.NewRecorder()
+
+		Convey("When the request is handled by the router, but the kafka service fails to send", func() {
+
+			h := hMocks.NewMockHelper(mockCtrl)
+			chv := chvMocks.NewMockCHValidator(mockCtrl)
+
+			common.InitEnv()
+			config.CallValidateConfig = func(cfg *config.Config) error {
+				return nil
+			}
+			cfg, _ := config.Get()
+
+			handler := NewDeltaValidationHandler(h, chv, cfg)
+
+			h.EXPECT().GetRequestIdFromHeader(req).Return(common.TestContextId)
+			chv.EXPECT().ValidateRequestAgainstOpenApiSpec(req, handler.cfg.OpenApiSpec, common.TestContextId).Return(nil, nil)
+
+			handler.ServeHTTP(resp, req)
+
+			Convey("Then the response should be 200 and no error returned", func() {
+				So(resp.Code, ShouldEqual, http.StatusOK)
+			})
+
+			common.DestroyEnv()
+		})
+	})
+}
+
+// TestDeltaValidationHandlerFailsValidation asserts that the DeltaValidationHandler returns a bad request status when validation fails
+func TestDeltaValidationHandlerFailsValidation(t *testing.T) {
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	Convey("Given a HTTP POST request via the officer delta endpoint", t, func() {
+
+		req := httptest.NewRequest(common.PostRestMethod, officersValidateEndpoint, bytes.NewBuffer([]byte(requestBody)))
+		resp := httptest.NewRecorder()
+
+		Convey("When the request is handled by the router, but the request body fails validation", func() {
+
+			h := hMocks.NewMockHelper(mockCtrl)
+			chv := chvMocks.NewMockCHValidator(mockCtrl)
+
+			common.InitEnv()
+			config.CallValidateConfig = func(cfg *config.Config) error {
+				return nil
+			}
+			cfg, _ := config.Get()
+
+			handler := NewDeltaValidationHandler(h, chv, cfg)
+
+			errBytes := []byte("error string")
+			h.EXPECT().GetRequestIdFromHeader(req).Return(common.TestContextId)
+			chv.EXPECT().ValidateRequestAgainstOpenApiSpec(req, handler.cfg.OpenApiSpec, common.TestContextId).Return(errBytes, nil)
+
+			handler.ServeHTTP(resp, req)
+
+			Convey("Then the response should be 400 and an error returned", func() {
+				So(resp.Code, ShouldEqual, http.StatusBadRequest)
+			})
+
+			common.DestroyEnv()
+		})
+	})
+}

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -34,6 +34,7 @@ func Register(mainRouter *mux.Router, cfg *config.Config, kSvc services.KafkaSer
 
 	appRouter := mainRouter.PathPrefix("").Subrouter()
 	appRouter.HandleFunc("/delta/officers", NewOfficerDeltaHandler(kSvc, h, chv, cfg).ServeHTTP).Methods(http.MethodPost).Name("officer-delta")
+	appRouter.HandleFunc("/delta/officers/validate", NewDeltaValidationHandler(h, chv, cfg).ServeHTTP).Methods(http.MethodPost).Name("officer-delta-validate")
 	appRouter.Use(userAuthInterceptor.UserAuthenticationIntercept)
 
 	return nil

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -37,6 +37,7 @@ func TestRegister(t *testing.T) {
 		err := Register(router, cfg, kSvc)
 		So(router.GetRoute("healthcheck"), ShouldNotBeNil)
 		So(router.GetRoute("officer-delta"), ShouldNotBeNil)
+		So(router.GetRoute("officer-delta-validate"), ShouldNotBeNil)
 		So(err, ShouldBeNil)
 	})
 }


### PR DESCRIPTION
Add an endpoint which only validates the request body for officers. This endpoint calls the kin-openapi library to validate and returns a response depending on the outcome of the validation.
Add validate endpoint to register and api-spec
Add new handler that only calls the validation function
Create util test file that has common functionality for handler tests

DSND-96