### PR TITLE
Rework the officer-delta-spec to no longer use oneOf

### DIFF
--- a/apispec/officer-delta-spec.yml
+++ b/apispec/officer-delta-spec.yml
@@ -119,17 +119,17 @@ components:
           type: string
 
     Identification:
-      oneOf:
-        - properties:
-            EEA:
-              $ref: '#/components/schemas/EEA'
-            non_eea:
-              $ref: '#/components/schemas/EEA'
-            UK_limited_company:
-              $ref: '#/components/schemas/EEA'
-            other_corporate_body_or_firm:
-              $ref: '#/components/schemas/EEA'
-
+      type: object
+      properties:
+        EEA:
+          $ref: '#/components/schemas/EEA'
+        non_eea:
+          $ref: '#/components/schemas/EEA'
+        UK_limited_company:
+          $ref: '#/components/schemas/EEA'
+        other_corporate_body_or_firm:
+          $ref: '#/components/schemas/EEA'
+      maxProperties: 1
 
     EEA:
       type: object

--- a/validation/schema_testing/officers/officerDeltaSchema_test.go
+++ b/validation/schema_testing/officers/officerDeltaSchema_test.go
@@ -27,6 +27,7 @@ const (
 	officersEndpoint = "/delta/officers"
 	apiSpecLocation  = "../../../apispec/api-spec.yml"
 	contextId        = "contextId"
+	methodPost		 = "POST"
 )
 
 // TestOfficerDeltaSchemaNoErrors asserts that when a valid request body is given which matches the schema, then no
@@ -37,7 +38,7 @@ func TestOfficerDeltaSchemaNoErrors(t *testing.T) {
 
 		okRequestBody := common.ReadRequestBody(okRequestBodyLocation)
 
-		r := httptest.NewRequest("POST", officersEndpoint, bytes.NewBuffer(okRequestBody))
+		r := httptest.NewRequest(methodPost, officersEndpoint, bytes.NewBuffer(okRequestBody))
 		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing a valid request", func() {
@@ -61,7 +62,7 @@ func TestOfficerDeltaSchemaTypeErrors(t *testing.T) {
 
 		typeErrorRequestBody := common.ReadRequestBody(typeErrorRequestBodyLocation)
 
-		r := httptest.NewRequest("POST", officersEndpoint, bytes.NewBuffer(typeErrorRequestBody))
+		r := httptest.NewRequest(methodPost, officersEndpoint, bytes.NewBuffer(typeErrorRequestBody))
 		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing an valid request with type errors", func() {
@@ -89,7 +90,7 @@ func TestOfficerDeltaSchemaRequiredErrors(t *testing.T) {
 
 		mandatoryErrorsRequestBody := common.ReadRequestBody(requiredErrorRequestBodyLocation)
 
-		r := httptest.NewRequest("POST", officersEndpoint, bytes.NewBuffer(mandatoryErrorsRequestBody))
+		r := httptest.NewRequest(methodPost, officersEndpoint, bytes.NewBuffer(mandatoryErrorsRequestBody))
 		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing an valid request with missing mandatory values", func() {
@@ -117,7 +118,7 @@ func TestOfficerDeltaSchemaEnumErrors(t *testing.T) {
 
 		enumErrorsRequestBody := common.ReadRequestBody(enumErrorRequestBodyLocation)
 
-		r := httptest.NewRequest("POST", officersEndpoint, bytes.NewBuffer(enumErrorsRequestBody))
+		r := httptest.NewRequest(methodPost, officersEndpoint, bytes.NewBuffer(enumErrorsRequestBody))
 		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing an valid request with incorrect ENUM values", func() {
@@ -143,7 +144,7 @@ func TestOfficerDeltaSchemaNoRequestBodyError(t *testing.T) {
 
 	Convey("Given I want to test the officers-delta API schema to assert validation is working correctly", t, func() {
 
-		r := httptest.NewRequest("POST", officersEndpoint, bytes.NewBuffer(nil))
+		r := httptest.NewRequest(methodPost, officersEndpoint, bytes.NewBuffer(nil))
 		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing an empty request body", func() {
@@ -171,7 +172,7 @@ func TestOfficerDeltaSchemaMaxPropertiesError(t *testing.T) {
 
 		maxPropertiesErrorRequestBody := common.ReadRequestBody(maxPropertiesRequestBodyLocation)
 
-		r := httptest.NewRequest("POST", officersEndpoint, bytes.NewBuffer(maxPropertiesErrorRequestBody))
+		r := httptest.NewRequest(methodPost, officersEndpoint, bytes.NewBuffer(maxPropertiesErrorRequestBody))
 		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing an valid request with maxProperty constraint errors", func() {

--- a/validation/schema_testing/officers/officerDeltaSchema_test.go
+++ b/validation/schema_testing/officers/officerDeltaSchema_test.go
@@ -15,12 +15,14 @@ const (
 	typeErrorRequestBodyLocation     = requestBodiesLocation + "type_error_request_body"
 	requiredErrorRequestBodyLocation = requestBodiesLocation + "required_error_request_body"
 	enumErrorRequestBodyLocation     = requestBodiesLocation + "enum_error_request_body"
+	maxPropertiesRequestBodyLocation = requestBodiesLocation + "max_properties_request_body"
 
 	responseBodiesLocation                 = "./response_bodies/"
 	typeErrorResponseBodyLocation          = responseBodiesLocation + "type_error_response_body"
 	requiredErrorResponseBodyLocation      = responseBodiesLocation + "required_error_response_body"
 	enumErrorResponseBodyLocation          = responseBodiesLocation + "enum_error_response_body"
 	noRequestBodyErrorResponseBodyLocation = responseBodiesLocation + "no_request_body_error_response_body"
+	maxPropertiesResponseBodyLocation      = responseBodiesLocation + "max_properties_response_body"
 
 	officersEndpoint = "/delta/officers"
 	apiSpecLocation  = "../../../apispec/api-spec.yml"
@@ -153,6 +155,34 @@ func TestOfficerDeltaSchemaNoRequestBodyError(t *testing.T) {
 			Convey("Then I am given an error saying no request body provided", func() {
 				noRequestBodyErrorsResponseBody := common.ReadRequestBody(noRequestBodyErrorResponseBodyLocation)
 				match := common.CompareActualToExpected(validationErrs, noRequestBodyErrorsResponseBody)
+
+				So(validationErrs, ShouldNotBeNil)
+				So(match, ShouldEqual, true)
+			})
+		})
+	})
+}
+
+// TestOfficerDeltaSchemaMaxPropertiesError asserts that when an invalid request body is given which breaks the allowed
+// bounds on the maxProperties field for the Identification object, then an errors array is returned.
+func TestOfficerDeltaSchemaMaxPropertiesError(t *testing.T) {
+
+	Convey("Given I want to test the officers-delta API schema for maxProperty constraints", t, func() {
+
+		maxPropertiesErrorRequestBody := common.ReadRequestBody(maxPropertiesRequestBodyLocation)
+
+		r := httptest.NewRequest("POST", officersEndpoint, bytes.NewBuffer(maxPropertiesErrorRequestBody))
+		r = common.SetHeaders(r)
+
+		Convey("When I call to validate the request body, providing an valid request with maxProperty constraint errors", func() {
+
+			chv := validation.NewCHValidator()
+
+			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
+
+			Convey("Then I am given an errors array response as validation errors have been found", func() {
+				maxPropertiesErrorResponseBody := common.ReadRequestBody(maxPropertiesResponseBodyLocation)
+				match := common.CompareActualToExpected(validationErrs, maxPropertiesErrorResponseBody)
 
 				So(validationErrs, ShouldNotBeNil)
 				So(match, ShouldEqual, true)

--- a/validation/schema_testing/officers/request_bodies/enum_error_request_body
+++ b/validation/schema_testing/officers/request_bodies/enum_error_request_body
@@ -31,24 +31,6 @@
           "registration_number": "string",
           "legal_authority": "string",
           "legal_form": "string"
-        },
-        "non_eea": {
-          "place_registered": "string",
-          "registration_number": "string",
-          "legal_authority": "string",
-          "legal_form": "string"
-        },
-        "UK_limited_company": {
-          "place_registered": "string",
-          "registration_number": "string",
-          "legal_authority": "string",
-          "legal_form": "string"
-        },
-        "other_corporate_body_or_firm": {
-          "place_registered": "string",
-          "registration_number": "string",
-          "legal_authority": "string",
-          "legal_form": "string"
         }
       },
       "service_address": {

--- a/validation/schema_testing/officers/request_bodies/max_properties_request_body
+++ b/validation/schema_testing/officers/request_bodies/max_properties_request_body
@@ -1,0 +1,72 @@
+{
+  "officers": [
+    {
+      "company_number": "string",
+      "changed_at": "string",
+      "kind": "string",
+      "internal_id": "string",
+      "appointment_date": "string",
+      "title": "string",
+      "corporate_ind": "Y",
+      "surname": "string",
+      "forename": "string",
+      "middle_name": "string",
+      "date_of_birth": "string",
+      "service_address_same_as_registered_address": "Y",
+      "nationality": "string",
+      "occupation": "string",
+      "officer_id": "string",
+      "secure_director": "Y",
+      "officer_detail_id": "string",
+      "officer_role": "string",
+      "usual_residential_country": "string",
+      "previous_name_array": {
+        "previous_surname": "string",
+        "previous_forename": "string",
+        "previous_timestamp": "string"
+      },
+      "identification": {
+        "EEA": {
+          "place_registered": "string",
+          "registration_number": "string",
+          "legal_authority": "string",
+          "legal_form": "string"
+        },
+        "non-eea": {
+          "place_registered": "string",
+          "registration_number": "string",
+          "legal_authority": "string",
+          "legal_form": "string"
+        }
+      },
+      "service_address": {
+        "premise": "string",
+        "address_line_1": "string",
+        "address_line_2": "string",
+        "locality": "string",
+        "care_of": "string",
+        "region": "string",
+        "po_box": "string",
+        "supplied_company_name": "string",
+        "country": "string",
+        "postal_code": "string",
+        "usual_country_of_residence": "string"
+      },
+      "usual_residential_address": {
+        "premise": "string",
+        "address_line_1": "string",
+        "address_line_2": "string",
+        "locality": "string",
+        "care_of": "string",
+        "region": "string",
+        "po_box": "string",
+        "supplied_company_name": "string",
+        "country": "string",
+        "postal_code": "string",
+        "usual_country_of_residence": "string"
+      }
+    }
+  ],
+  "CreatedTime": "string",
+  "delta_at": "string"
+}

--- a/validation/schema_testing/officers/request_bodies/ok_request_body
+++ b/validation/schema_testing/officers/request_bodies/ok_request_body
@@ -31,24 +31,6 @@
           "registration_number": "string",
           "legal_authority": "string",
           "legal_form": "string"
-        },
-        "non_eea": {
-          "place_registered": "string",
-          "registration_number": "string",
-          "legal_authority": "string",
-          "legal_form": "string"
-        },
-        "UK_limited_company": {
-          "place_registered": "string",
-          "registration_number": "string",
-          "legal_authority": "string",
-          "legal_form": "string"
-        },
-        "other_corporate_body_or_firm": {
-          "place_registered": "string",
-          "registration_number": "string",
-          "legal_authority": "string",
-          "legal_form": "string"
         }
       },
       "service_address": {

--- a/validation/schema_testing/officers/request_bodies/required_error_request_body
+++ b/validation/schema_testing/officers/request_bodies/required_error_request_body
@@ -25,24 +25,6 @@
           "registration_number": "string",
           "legal_authority": "string",
           "legal_form": "string"
-        },
-        "non_eea": {
-          "place_registered": "string",
-          "registration_number": "string",
-          "legal_authority": "string",
-          "legal_form": "string"
-        },
-        "UK_limited_company": {
-          "place_registered": "string",
-          "registration_number": "string",
-          "legal_authority": "string",
-          "legal_form": "string"
-        },
-        "other_corporate_body_or_firm": {
-          "place_registered": "string",
-          "registration_number": "string",
-          "legal_authority": "string",
-          "legal_form": "string"
         }
       },
       "service_address": {

--- a/validation/schema_testing/officers/request_bodies/type_error_request_body
+++ b/validation/schema_testing/officers/request_bodies/type_error_request_body
@@ -31,24 +31,6 @@
           "registration_number": 123,
           "legal_authority": 123,
           "legal_form": 123
-        },
-        "non_eea": {
-          "place_registered": 123,
-          "registration_number": 123,
-          "legal_authority": 123,
-          "legal_form": 123
-        },
-        "UK_limited_company": {
-          "place_registered": 123,
-          "registration_number": 123,
-          "legal_authority": 123,
-          "legal_form": 123
-        },
-        "other_corporate_body_or_firm": {
-          "place_registered": 123,
-          "registration_number": 123,
-          "legal_authority": 123,
-          "legal_form": 123
         }
       },
       "service_address": {

--- a/validation/schema_testing/officers/response_bodies/max_properties_response_body
+++ b/validation/schema_testing/officers/response_bodies/max_properties_response_body
@@ -1,0 +1,11 @@
+[
+    {
+        "error": "there must be at most 1 properties",
+        "error_values": {
+            "identification": "map[EEA:map[legal_authority:string legal_form:string place_registered:string registration_number:string] non-eea:map[legal_authority:string legal_form:string place_registered:string registration_number:string]]"
+        },
+        "location": "officers.0.identification",
+        "location_type": "json-path",
+        "type": "ch:validation"
+    }
+]

--- a/validation/schema_testing/officers/response_bodies/type_error_response_body
+++ b/validation/schema_testing/officers/response_bodies/type_error_response_body
@@ -225,11 +225,38 @@
         "type": "ch:validation"
     },
     {
-        "error": "",
+        "error": "Field must be set to string or not be present",
         "error_values": {
-            "identification": "map[EEA:map[legal_authority:123 legal_form:123 place_registered:123 registration_number:123] UK_limited_company:map[legal_authority:123 legal_form:123 place_registered:123 registration_number:123] non_eea:map[legal_authority:123 legal_form:123 place_registered:123 registration_number:123] other_corporate_body_or_firm:map[legal_authority:123 legal_form:123 place_registered:123 registration_number:123]]"
+            "place_registered": "number, integer"
         },
-        "location": "officers.0.identification",
+        "location": "officers.0.identification.EEA.place_registered",
+        "location_type": "json-path",
+        "type": "ch:validation"
+    },
+    {
+        "error": "Field must be set to string or not be present",
+        "error_values": {
+            "registration_number": "number, integer"
+        },
+        "location": "officers.0.identification.EEA.registration_number",
+        "location_type": "json-path",
+        "type": "ch:validation"
+    },
+    {
+        "error": "Field must be set to string or not be present",
+        "error_values": {
+            "legal_authority": "number, integer"
+        },
+        "location": "officers.0.identification.EEA.legal_authority",
+        "location_type": "json-path",
+        "type": "ch:validation"
+    },
+    {
+        "error": "Field must be set to string or not be present",
+        "error_values": {
+            "legal_form": "number, integer"
+        },
+        "location": "officers.0.identification.EEA.legal_form",
         "location_type": "json-path",
         "type": "ch:validation"
     },


### PR DESCRIPTION
as it wasn't the right validation type for our schema

We now use a maxProperties field set to 1 which stops the
requester providing multiple properties inside of the Identification
field.

This also fixes the issue of getting a badly formatted error back
which was a side effect of using oneOf.