### PR TITLE
Remove use of sync.Once due to nil pointer issue identified

### DIFF
--- a/handlers/register.go
+++ b/handlers/register.go
@@ -13,12 +13,23 @@ import (
 	"github.com/gorilla/mux"
 )
 
+var (
+	callNewCHValidator = validation.NewCHValidator
+)
+
 // Register defines all REST endpoints for the API.
 func Register(mainRouter *mux.Router, cfg *config.Config, kSvc services.KafkaService) error {
 
 	// Initialise all services and components needed to run chs-delta-api correctly.
 	h := helpers.NewHelper()
-	chv := validation.NewCHValidator()
+
+	// Init the CHValidator service and handle any errors that come back.
+	chv, err := callNewCHValidator(cfg.OpenApiSpec)
+	if err != nil {
+		return err
+	}
+
+	// Init the Kafka service and handle any errors that come back.
 	if err := kSvc.Init(cfg); err != nil {
 		return err
 	}

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"github.com/companieshouse/chs-delta-api/config"
 	"github.com/companieshouse/chs-delta-api/services/mocks"
+	"github.com/companieshouse/chs-delta-api/validation"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
 	"net/http"
@@ -29,6 +30,14 @@ func TestUnitRegister(t *testing.T) {
 
 	Convey("When we call the register function then all routes are registered", t, func() {
 		router := mux.NewRouter()
+
+		callNewCHValidator = func(openApiSpec string) (validation.CHValidator, error) {
+			return &validation.CHValidatorImpl{}, nil
+		}
+
+		config.CallValidateConfig = func(cfg *config.Config) error {
+			return nil
+		}
 		cfg, _ := config.Get()
 		kSvc := mocks.NewMockKafkaService(mockCtrl)
 

--- a/services/kafkaService_test.go
+++ b/services/kafkaService_test.go
@@ -33,6 +33,9 @@ func TestUnitNewKafkaService(t *testing.T) {
 // TestUnitKafkaServiceInitSuccessful asserts that the Init method successfully creates and initialises a KafkaServiceImpl.
 func TestUnitKafkaServiceInitSuccessful(t *testing.T) {
 
+	config.CallValidateConfig = func(cfg *config.Config) error {
+		return nil
+	}
 	cfg, _ := config.Get()
 
 	Convey("Given a call to init a Kafka service", t, func() {

--- a/validation/schema_testing/officers/officerDeltaSchema_test.go
+++ b/validation/schema_testing/officers/officerDeltaSchema_test.go
@@ -27,7 +27,7 @@ const (
 	officersEndpoint = "/delta/officers"
 	apiSpecLocation  = "../../../apispec/api-spec.yml"
 	contextId        = "contextId"
-	methodPost		 = "POST"
+	methodPost       = "POST"
 )
 
 // TestUnitOfficerDeltaSchemaNoErrors asserts that when a valid request body is given which matches the schema, then no
@@ -43,7 +43,7 @@ func TestUnitOfficerDeltaSchemaNoErrors(t *testing.T) {
 
 		Convey("When I call to validate the request body, providing a valid request", func() {
 
-			chv := validation.NewCHValidator()
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
 
 			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
 
@@ -67,7 +67,7 @@ func TestUnitOfficerDeltaSchemaTypeErrors(t *testing.T) {
 
 		Convey("When I call to validate the request body, providing an valid request with type errors", func() {
 
-			chv := validation.NewCHValidator()
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
 
 			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
 
@@ -95,7 +95,7 @@ func TestUnitOfficerDeltaSchemaRequiredErrors(t *testing.T) {
 
 		Convey("When I call to validate the request body, providing an valid request with missing mandatory values", func() {
 
-			chv := validation.NewCHValidator()
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
 
 			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
 
@@ -123,7 +123,7 @@ func TestUnitOfficerDeltaSchemaEnumErrors(t *testing.T) {
 
 		Convey("When I call to validate the request body, providing an valid request with incorrect ENUM values", func() {
 
-			chv := validation.NewCHValidator()
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
 
 			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
 
@@ -149,7 +149,7 @@ func TestUnitOfficerDeltaSchemaNoRequestBodyError(t *testing.T) {
 
 		Convey("When I call to validate the request body, providing an empty request body", func() {
 
-			chv := validation.NewCHValidator()
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
 
 			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
 
@@ -166,7 +166,7 @@ func TestUnitOfficerDeltaSchemaNoRequestBodyError(t *testing.T) {
 
 // TestOfficerDeltaSchemaMaxPropertiesError asserts that when an invalid request body is given which breaks the allowed
 // bounds on the maxProperties field for the Identification object, then an errors array is returned.
-func TestOfficerDeltaSchemaMaxPropertiesError(t *testing.T) {
+func TestUnitOfficerDeltaSchemaMaxPropertiesError(t *testing.T) {
 
 	Convey("Given I want to test the officers-delta API schema for maxProperty constraints", t, func() {
 
@@ -177,7 +177,7 @@ func TestOfficerDeltaSchemaMaxPropertiesError(t *testing.T) {
 
 		Convey("When I call to validate the request body, providing an valid request with maxProperty constraint errors", func() {
 
-			chv := validation.NewCHValidator()
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
 
 			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, apiSpecLocation, contextId)
 


### PR DESCRIPTION
We identified a nil pointer reference issue which was resulting
in a panic occuring and the application not running correctly.
The issue was due to the way that we created and used the CHValidator service.

When we create the CHValidator service, it contains a nil pointer for it's doc
member variable, this doc pointer is later updated to reference a schema location
in memory when we call to validate a request. We found that using sync.Once loaded the
doc pointer fine for the 1st handler, but when other handlers attempted to load the doc
they were being stopped by sync.Once and then trying to validate using a nil doc pointer.

We have removed the use of sync.Once and instead opted to move the assignment of the doc
to the constructor of the CHValidator, as this constructor is called once in Register.go
on applications start up, it doesn't have to worry about threading issues. We then pass
that fully instantiated object as a copy to each new handler when it is registered
for each endpoint, which means that all endpoints have the document loaded before calling
their validate method.

This caused a lot of unit tests to break as logic had been reworked and reshaped,
So this PR also includes changes to unit tests to fix and update them to correctly
cover the new logic.

Go fmt also ran.

This solves **DSND-122**