### PR TITLE
Add flags to the unit test running command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: test-unit test-integration
 
 .PHONY: test-unit
 test-unit:
-	go test $(TESTS) -covermode=atomic -coverpkg=./... -run 'Unit' -coverprofile=coverage.out
+	go test -covermode=atomic -coverpkg=./... -run 'Unit' -coverprofile=coverage.out
 
 .PHONY: test-integration
 test-integration:


### PR DESCRIPTION
Currently Sonar shows wrong coverage as the packages are tested individually
while in IDE the collective coverage for the packages are much higher than
Sonar. Adding these flags to test command ensures coverage is gathered
as a whole.