### PR TITLE
Change Kafka message distribution strategy

### DIFF
--- a/services/kafkaService.go
+++ b/services/kafkaService.go
@@ -76,7 +76,7 @@ func initSchema(cfg *config.Config) (string, error) {
 func initProducer(cfg *config.Config) (*producer.Producer, error) {
 	// Create a new Kafka Producer which will be used to publish our message onto a given Kafka topic.
 	log.Info("Using Streaming Kafka broker Address", log.Data{"Brokers": cfg.BrokerAddr})
-	p, err := callProducerNew(&producer.Config{Acks: &producer.WaitForAll, BrokerAddrs: cfg.BrokerAddr})
+	p, err := callProducerNew(&producer.Config{Acks: &producer.WaitForAll, BrokerAddrs: cfg.BrokerAddr, RoundRobinPartitioner: true})
 	if err != nil {
 		log.Error(fmt.Errorf("error initialising producer: %s", err))
 		return nil, err
@@ -109,7 +109,6 @@ func (kSvc *KafkaServiceImpl) SendMessage(topic, data, contextId string) error {
 	producerMessage := &producer.Message{
 		Topic:     topic,
 		Value:     sarama.ByteEncoder(messageBytes),
-		Partition: 0,
 	}
 
 	// Finally try to send the message.


### PR DESCRIPTION
The library used in our apps uses message distribution in Kafka
partitions as hash partitioning. Since most of the time we do not
provide Keys which are vital for hash partitioning to correctly
distribute the messages to the correct partitions. In this case we
need to either use Manual Partitioning or Round Robin Partitioning
or even we could come up with the custom partitioning strategy. In
our case, Round Robin Partitioning would be ideal as we do not care
about ordering and messages will be distributed equally to all the
partitions in a topic.

Resolves: DNSD-172