### PR TITLE
Add logging structure to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,6 @@ command or run the following steps to build image locally:
 2. `DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/chs-delta-api .`
 3. `docker run 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/chs-delta-api:latest`
 
-## Logging
-This application uses the following standard format to log messages using the chs.go logger:
-
-```go
-{"context":"contextID","created":"date-time stamp","data":{"message":"message_text"},"event":"log_leveL","namespace":"chs-delta-api"}
-```
-
-With an example of this being:
-```go
-{"context":"bJvOa4n6k-HsVlvLz1h3uuHqxxMi","created":"2021-09-13T07:00:49.028270306+01:00","data":{"message":"Request validated. No errors were found."},"event":"info","namespace":"chs-delta-api"}
-```
 ## Healthcheck
 This service implements a `healthcheck` endpoint. Using POSTMAN call the `/delta/healthcheck` GET endpoint to assert 
 the service is running correctly.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,17 @@ command or run the following steps to build image locally:
 2. `DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/chs-delta-api .`
 3. `docker run 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/chs-delta-api:latest`
 
+## Logging
+This application uses the following standard format to log messages using the chs.go logger:
 
+```go
+{"context":"contextID","created":"date-time stamp","data":{"message":"message_text"},"event":"log_leveL","namespace":"chs-delta-api"}
+```
+
+With an example of this being:
+```go
+{"context":"bJvOa4n6k-HsVlvLz1h3uuHqxxMi","created":"2021-09-13T07:00:49.028270306+01:00","data":{"message":"Request validated. No errors were found."},"event":"info","namespace":"chs-delta-api"}
+```
 ## Healthcheck
 This service implements a `healthcheck` endpoint. Using POSTMAN call the `/delta/healthcheck` GET endpoint to assert 
 the service is running correctly.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,39 @@
+# Logging in the chs-delta-api
+
+This application uses the following standard format to log messages using the chs.go logger.
+
+## Successful journey
+
+When a request is successful you will get the following stack of logs:
+```go
+{"context":"context_id","created":"date_time_stamp","data":{"message":"message_text","message_key":"message_key_value"},"event":"info","namespace":"chs-delta-api"}
+{"context":"context_id","created":"date_time_stamp","data":{"message":"message_text"},"event":"info","namespace":"chs-delta-api"}
+{"context":"context_id","created":"date_time_stamp","data":{"message":"message_text","offset":offset_int,"partition":partition_int,"topic":"officers-delta"},"event":"info","namespace":"chs-delta-api"}
+{"context":"context_id","created":"date_time_stamp","data":{"duration":time,"end":"date_time_stamp","method":"http_method","path":"url_path","start":"date_time_stamp","status":http_status},"event":"request","namespace":"chs-delta-api"}
+```
+
+With an example of this being:
+```go
+{"context":"zWJcenQdHgzRmoK1hL_ridjiybm1","created":"2021-09-13T12:19:29.820620448+01:00","data":{"message":"Validating request using: ","spec_location":"apispec/api-spec.yml"},"event":"info","namespace":"chs-delta-api"}
+{"context":"zWJcenQdHgzRmoK1hL_ridjiybm1","created":"2021-09-13T12:19:29.823892338+01:00","data":{"message":"Request validated. No errors were found."},"event":"info","namespace":"chs-delta-api"}
+{"context":"zWJcenQdHgzRmoK1hL_ridjiybm1","created":"2021-09-13T12:19:29.825429905+01:00","data":{"message":"Sending message","offset":1,"partition":6,"topic":"officers-delta"},"event":"info","namespace":"chs-delta-api"}
+{"context":"zWJcenQdHgzRmoK1hL_ridjiybm1","created":"2021-09-13T12:19:29.82546636+01:00","data":{"duration":time,"end":"2021-09-13T12:19:29.825462326+01:00","method":"POST","path":"/delta/officers","start":"2021-09-13T12:19:29.820460095+01:00","status":200},"event":"request","namespace":"chs-delta-api"}
+```
+
+## Validation error journey
+
+When a request returns validation errors you will get the following stack of logs:
+```go
+{"context":"context_id","created":"date_time_stamp","data":{"message":"message_text","message_key":"message_key_value"},"event":"info","namespace":"chs-delta-api"}
+{"context":"context_id","created":"date_time_stamp","data":{"message":"message_text"},"event":"info","namespace":"chs-delta-api"}
+{"context":"context_id","created":"date_time_stamp","data":{"error":{},"message":"ch_errors_object_array"},"event":"error","namespace":"chs-delta-api"}
+{"context":"context_id","created":"date_time_stamp","data":{"duration":time,"end":"date_time_stamp","method":"http_method","path":"url_path","start":"date_time_stamp","status":http_status},"event":"request","namespace":"chs-delta-api"}
+```
+
+With an example of this being:
+```go
+{"context":"Dy7rFtAq3G5G9m60MZ1jlgkgeyLD","created":"2021-09-14T11:03:02.042735672+01:00","data":{"message":"Validating request using: ","spec_location":"apispec/api-spec.yml"},"event":"info","namespace":"chs-delta-api"}
+{"context":"Dy7rFtAq3G5G9m60MZ1jlgkgeyLD","created":"2021-09-14T11:03:02.042891994+01:00","data":{"message":"Request validated. Errors found."},"event":"info","namespace":"chs-delta-api"}
+{"context":"Dy7rFtAq3G5G9m60MZ1jlgkgeyLD","created":"2021-09-14T11:03:02.045197901+01:00","data":{"error":{},"message":"{Error:value is not one of the allowed values, ErrorValues:map[secure_director:test], Location:officers.0.secure_director, LocationType:json-path, Type:ch:validation},"},"event":"error","namespace":"chs-delta-api"}
+{"context":"Dy7rFtAq3G5G9m60MZ1jlgkgeyLD","created":"2021-09-14T11:03:02.045648992+01:00","data":{"duration":3111079,"end":"2021-09-14T11:03:02.045644507+01:00","method":"POST","path":"/delta/officers","start":"2021-09-14T11:03:02.042533743+01:00","status":400},"event":"request","namespace":"chs-delta-api"}
+```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -60,10 +60,18 @@ With an example of this being:
 If a message fails to be sent to Kafka you will get the following logs:
 
 ```go
-{"context":"context_id","created":"date_time_stamp","data":{"error":kafka_error_int,"message":"kafka.","topic":"topic_choice"},"event":"error","namespace":"chs-delta-api"}
+{"context":"context_id","created":"date_time_stamp","data":{"error":kafka_error_int,"message":"kafka_message","topic":"topic_choice"},"event":"error","namespace":"chs-delta-api"}
 ```
 
-The message will be logged changes depending on the error kafka returns.
+The message that will be logged changes depending on the error Kafka returns. This can vary quite a bit, but here are 2 examples:
+
+```go
+"message":"kafka server: Replication-factor is invalid."
+```
+
+```go
+"message":"kafka server: In the middle of a leadership election, there is currently no leader for this partition and hence it is unavailable for writes."
+```
 
 The following variables are of interest to Kibana:
 
@@ -100,3 +108,14 @@ Example of a Validation Error request:
 ```go
 {"context":"Dy7rFtAq3G5G9m60MZ1jlgkgeyLD","created":"2021-09-14T11:03:02.045648992+01:00","data":{"duration":3111079,"end":"2021-09-14T11:03:02.045644507+01:00","method":"POST","path":"/delta/officers","start":"2021-09-14T11:03:02.042533743+01:00","status":400},"event":"request","namespace":"chs-delta-api"}
 ```
+
+---
+
+#### ContextId and its use in tracking requests from CHIPS to CHS
+The context_id variable as mentioned in other sections of this document is the variable which should be used to track a filing from CHIPS to CHS.
+It is retrieved / created in the chs-delta-api at the start of handling a request. First the chs-delta-api will attempt to pull the contxt_id from 
+the request headers; one of the provided headers from ERIC is the x-request-id, this is the context_id. If the x-request-id header is not present 
+then the chs-delta-api will create a context_id.
+
+It is passed with the request received from CHIPS onto a Kafka topic as part of the avro schema (inside the avro schema you will find the contextId field).
+A go struct implementation of the avro schema can be found in the `models/chsDelta.go` file.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,39 +1,102 @@
 # Logging in the chs-delta-api
-
 This application uses the following standard format to log messages using the chs.go logger.
 
-## Successful journey
+## Notable logs
+The following sub sections will cover all notable logs that are output by this service.
 
-When a request is successful you will get the following stack of logs:
+
+#### Validation fails
+if a request fails validation you will get the following log:
+
 ```go
-{"context":"context_id","created":"date_time_stamp","data":{"message":"message_text","message_key":"message_key_value"},"event":"info","namespace":"chs-delta-api"}
-{"context":"context_id","created":"date_time_stamp","data":{"message":"message_text"},"event":"info","namespace":"chs-delta-api"}
-{"context":"context_id","created":"date_time_stamp","data":{"message":"message_text","offset":offset_int,"partition":partition_int,"topic":"officers-delta"},"event":"info","namespace":"chs-delta-api"}
-{"context":"context_id","created":"date_time_stamp","data":{"duration":time,"end":"date_time_stamp","method":"http_method","path":"url_path","start":"date_time_stamp","status":http_status},"event":"request","namespace":"chs-delta-api"}
-```
-
-With an example of this being:
-```go
-{"context":"zWJcenQdHgzRmoK1hL_ridjiybm1","created":"2021-09-13T12:19:29.820620448+01:00","data":{"message":"Validating request using: ","spec_location":"apispec/api-spec.yml"},"event":"info","namespace":"chs-delta-api"}
-{"context":"zWJcenQdHgzRmoK1hL_ridjiybm1","created":"2021-09-13T12:19:29.823892338+01:00","data":{"message":"Request validated. No errors were found."},"event":"info","namespace":"chs-delta-api"}
-{"context":"zWJcenQdHgzRmoK1hL_ridjiybm1","created":"2021-09-13T12:19:29.825429905+01:00","data":{"message":"Sending message","offset":1,"partition":6,"topic":"officers-delta"},"event":"info","namespace":"chs-delta-api"}
-{"context":"zWJcenQdHgzRmoK1hL_ridjiybm1","created":"2021-09-13T12:19:29.82546636+01:00","data":{"duration":time,"end":"2021-09-13T12:19:29.825462326+01:00","method":"POST","path":"/delta/officers","start":"2021-09-13T12:19:29.820460095+01:00","status":200},"event":"request","namespace":"chs-delta-api"}
-```
-
-## Validation error journey
-
-When a request returns validation errors you will get the following stack of logs:
-```go
-{"context":"context_id","created":"date_time_stamp","data":{"message":"message_text","message_key":"message_key_value"},"event":"info","namespace":"chs-delta-api"}
 {"context":"context_id","created":"date_time_stamp","data":{"message":"message_text"},"event":"info","namespace":"chs-delta-api"}
 {"context":"context_id","created":"date_time_stamp","data":{"error":{},"message":"ch_errors_object_array"},"event":"error","namespace":"chs-delta-api"}
-{"context":"context_id","created":"date_time_stamp","data":{"duration":time,"end":"date_time_stamp","method":"http_method","path":"url_path","start":"date_time_stamp","status":http_status},"event":"request","namespace":"chs-delta-api"}
 ```
+
+The following message will be logged:
+```go
+"message":"Request validated. Errors found."
+```
+
+followed by a message containing the errors found.
+```go
+"message":"{Error:value is not one of the allowed values, ErrorValues:map[secure_director:test], Location:officers.0.secure_director, LocationType:json-path, Type:ch:validation},"
+```
+
+
+The following variables are of interest to Kibana:
+
+`"context":"context_id"` - This is the only variable which can be used to track a request through the full end to end journey.
 
 With an example of this being:
 ```go
-{"context":"Dy7rFtAq3G5G9m60MZ1jlgkgeyLD","created":"2021-09-14T11:03:02.042735672+01:00","data":{"message":"Validating request using: ","spec_location":"apispec/api-spec.yml"},"event":"info","namespace":"chs-delta-api"}
 {"context":"Dy7rFtAq3G5G9m60MZ1jlgkgeyLD","created":"2021-09-14T11:03:02.042891994+01:00","data":{"message":"Request validated. Errors found."},"event":"info","namespace":"chs-delta-api"}
 {"context":"Dy7rFtAq3G5G9m60MZ1jlgkgeyLD","created":"2021-09-14T11:03:02.045197901+01:00","data":{"error":{},"message":"{Error:value is not one of the allowed values, ErrorValues:map[secure_director:test], Location:officers.0.secure_director, LocationType:json-path, Type:ch:validation},"},"event":"error","namespace":"chs-delta-api"}
+```
+---
+
+#### Message sent to Kafka
+```go
+{"context":"context_id","created":"date_time_stamp","data":{"message":"message_text","offset":offset_int,"partition":partition_int,"topic":"topic_choice"},"event":"info","namespace":"chs-delta-api"}
+```
+The following message will be logged:
+```go
+"message":"Sent message"
+```
+
+The following variables are of interest to Kibana:
+
+`"context":"context_id"` - This is the only variable which can be used to track a request through the full end to end journey.
+
+`"offset":offset_int, "partition":partition_int` - These values are only returned if a message has successfully been sent to Kafka.
+
+With an example of this being:
+```go
+{"context":"zWJcenQdHgzRmoK1hL_ridjiybm1","created":"2021-09-13T12:19:29.825429905+01:00","data":{"message":"Sent message","offset":1,"partition":6,"topic":"officers-delta"},"event":"info","namespace":"chs-delta-api"}
+```
+---
+
+#### Message fails to be sent to Kafka
+If a message fails to be sent to Kafka you will get the following logs:
+
+```go
+{"context":"context_id","created":"date_time_stamp","data":{"error":kafka_error_int,"message":"kafka.","topic":"topic_choice"},"event":"error","namespace":"chs-delta-api"}
+```
+
+The message will be logged changes depending on the error kafka returns.
+
+The following variables are of interest to Kibana:
+
+`"context":"context_id"` - This is the only variable which can be used to track a request through the full end to end journey.
+
+`"error":kafka_error_int` - This is the error code returned by Kafka which will allow you to trace the cause of the error.
+
+`"topic":"topic_choice"` - This is the topic which was attempted to send the message too.
+
+With an example of this being:
+```go
+{"context":"aaron-temp-id","created":"2021-09-14T13:01:48.67308Z","data":{"error":5,"message":"kafka server: In the middle of a leadership election, there is currently no leader for this partition and hence it is unavailable for writes.","topic":"officers-delta"},
+"event":"error","namespace":"chs-delta-api"}
+```
+
+---
+
+#### Status codes logged
+
+`"status":http_status` - Below is a full list of HTTP status codes returned by this service, to indicate whether a request was successful or not:
+- `200` (Successful request)
+- `400` (Validation error)
+- `500` (Internal Server Error)
+- `401` (Unauthorized)
+
+This does not cover other status codes such as timeouts and responses from other services such as ERIC.
+
+Example of a Successful request:
+```go
+{"context":"zWJcenQdHgzRmoK1hL_ridjiybm1","created":"2021-09-13T12:19:29.82546636+01:00","data":{"duration":time,"end":"2021-09-13T12:19:29.825462326+01:00","method":"POST","path":"/delta/officers","start":"2021-09-13T12:19:29.820460095+01:00","status":200},"event":"request","namespace":"chs-delta-api"}
+```
+ 
+Example of a Validation Error request:
+```go
 {"context":"Dy7rFtAq3G5G9m60MZ1jlgkgeyLD","created":"2021-09-14T11:03:02.045648992+01:00","data":{"duration":3111079,"end":"2021-09-14T11:03:02.045644507+01:00","method":"POST","path":"/delta/officers","start":"2021-09-14T11:03:02.042533743+01:00","status":400},"event":"request","namespace":"chs-delta-api"}
 ```


### PR DESCRIPTION
Create a logging document inside of the documentation directory of our service. This document will display notable log lines and variables which are of interest to other teams, front end support and logging tools such as Kibana.

**Resolves DSND-171**