### PR TITLE
Update message based on outcome of callSend

### DIFF
--- a/services/kafkaService.go
+++ b/services/kafkaService.go
@@ -113,8 +113,12 @@ func (kSvc *KafkaServiceImpl) SendMessage(topic, data, contextId string) error {
 
 	// Finally try to send the message.
 	partition, offset, err := callSend(kSvc, producerMessage)
-	log.InfoC(contextId, "Sending message", log.Data{config.TopicKey: producerMessage.Topic, config.PartitionKey: partition, config.OffsetKey: offset})
-	return err
+	if err != nil {
+		return err
+	}
+
+	log.InfoC(contextId, "Sent message", log.Data{config.TopicKey: producerMessage.Topic, config.PartitionKey: partition, config.OffsetKey: offset})
+	return nil
 }
 
 // sendViaProducer is used to add an abstraction layer for unit testing when calling to send a message via a producer.

--- a/services/kafkaService.go
+++ b/services/kafkaService.go
@@ -107,8 +107,8 @@ func (kSvc *KafkaServiceImpl) SendMessage(topic, data, contextId string) error {
 
 	// Create the producer message which will contain a topic, our message and a default partition.
 	producerMessage := &producer.Message{
-		Topic:     topic,
-		Value:     sarama.ByteEncoder(messageBytes),
+		Topic: topic,
+		Value: sarama.ByteEncoder(messageBytes),
 	}
 
 	// Finally try to send the message.


### PR DESCRIPTION
Previously the log line was printed regardless of whether the
callSend was successful or not. We do not print this line when the
callSend returns error.