### PR TITLE
Create openAPI spec for Insolvency Delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Environment Variables
 | KAFKA_BROKER_ADDR                 | chs-kafka:9092                    | Kafka broker address (can be comma separated)      | YES             |               |
 | SCHEMA_REGISTRY_URL               | http://chs-kafka:8081             | Schema registry URL                                | YES             |               |
 | OFFICER_DELTA_TOPIC               | officers-delta                    | Officer Delta Kafka topic to write messages to     | YES             |               |
+| INSOLVENCY_DELTA_TOPIC            | insolvency-delta                  | Insolvency Delta Kafka topic to write messages to  | YES             |               |
 | OPEN_API_SPEC                     | ./apispec/apispec.yml             | OpenAPI schema location                            | YES             |               |
 | LOG_LEVEL                         | trace                             | The level at which the logger prints               | NO              | info          |
 

--- a/apispec/api-spec.yml
+++ b/apispec/api-spec.yml
@@ -9,6 +9,11 @@ paths:
     $ref: 'officer-delta-spec.yml'
   /delta/officers/validate:
     $ref: 'officer-delta-spec.yml'
+  /delta/insolvency:
+    $ref: 'insolvency-delta-spec.yml'
+  /delta/insolvency/validate:
+    $ref: 'insolvency-delta-spec.yml'
+
 
 components:
   securitySchemes:

--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -1,157 +1,145 @@
 post:
   summary: Accepts an incoming insolvency delta, transforms it into an avro schema and puts it onto a Kafka topic.
   requestBody:
-    required: true
     content:
       application/json:
         schema:
-          oneOf:
-            - $ref: '#/components/schemas/Insolvency_delta_compulsory_liq'
-            - $ref: '#/components/schemas/Insolvency_delta_creditors-voluntary-liq'
-            - ...
-          discriminator:
-            propertyName: case_type
-            mapping:
-              compulsory-liquidation: '#/components/schemas/Insolvency_delta_compulsory_liq'
-              creditors-voluntary-liquidation: '#/components/schemas/Insolvency_delta_creditors-voluntary-liq'
-
+          $ref: '#/components/schemas/CommonModelFields'
+    required: true
   responses:
-    '200':
+    "200":
       description: Successfully produced message onto Kafka topic.
-    '400':
+    "400":
       description: Bad request body - validation errors.
-    '401':
+    "401":
       description: Unauthorised - missing api key in header.
-    '500':
+    "500":
       description: Internal server error has occured.
-
 components:
   schemas:
     CommonModelFields:
+      required:
+      - case_type
       type: object
       properties:
-        title: # fixed string
+        title:
           type: string
         company_number:
-          type: string
           maxLength: 10
-        case_numbers:
-          type: array
-          items:
-            $ref: '#/components/schemas/Case_number_array'
+          type: string
         case_type_id:
           type: number
           enum:
-            - 1
-            - 2
-            - 3
-            - 5
-            - 6
-            - 7
-            - 8
-            - 13
-            - 14
-            - 15
-            - 17
-
-
-    Insolvency_delta_compulsory_liq:
-      allOf:     # Combines the CommonModelFields and the inline case type specific model
-        - $ref: '#/components/schemas/CommonModelFields'
-        - type: object
-          properties:
-              case_type:
-                type: string
-              wind_up_date:
-                type: string
-              petition_date:
-                type: string
-              wind_up_conclusion_date: 
-                type: string
-              dissolved_date:
-                type: string
-              dissolved_due_date:
-                type: string
-          required:
-            - case_type
-    
-    Insolvency_delta_creditors-voluntary-liq:
-      allOf:     # Combines the CommonModelFields and the inline case type specific model
-        - $ref: '#/components/schemas/CommonModelFields'
-        - type: object
-          properties:
-              case_type:
-                type: string
-              wind_up_date:
-                type: string
-              dissolved_date:
-                type: string
-              dissolved_due_date:
-                type: string
-          required:
-            - case_type
-
-
-        
-
-
-
-
-
-    Insolvency_delta:
-      type: object
-      properties:
-        
+          - 1
+          - 2
+          - 3
+          - 5
+          - 6
+          - 7
+          - 8
+          - 13
+          - 14
+          - 15
+          - 17
         case_type:
           type: string
-          enum:
-            - "Members Voluntary Liquidation"
-            - "Creditors Voluntary Liquidation"
-            - "Compulsory Liquidation"
-            - "Official Receiver"
-            - "Receiver/Manager"
-            - "Administrative Receiver"
-            - "Administration"
-            - "Corporate Voluntary Arrangement"
-            - "Declaration of solvency"
-            - "Dummy"
-            - "Liquidation - 'Stay'"
-            - "Provisional Liquidator"
-            - "In Administration"
-            - "CVA Moratoria"
-            - "Foreign Insolvency"
-            - "Administrative Receiver - court"
-            - "Moratorium"
-        wind_up_date:
-          type: string
-        petition_date:
-          type: string
-        wind_up_conclusion_date: 
-          type: string
-        dissolved_date:
-          type: string
-        dissolved_due_date:
-          type: string
-        sworn_date:
-          type: string
-        admin_start_date:
-          type: string
-        admin_end_date:
-          type: string
-        report_date:
-          type: string
-        completion_date:
-          type: string
-        appointment_date:
-          type: string
-        end_date:
-          type: string
-        admin_order_date:
-          type: string
-        discharge_admin_order_date:
-          type: string
-        instrument_date:
-          type: string
-
-
-
+      discriminator:
+        propertyName: case_type
+        mapping:
+          members-voluntary-liquidation: '#/components/schemas/Members-voluntary-liquidation'
+          creditors-voluntary-liquidation: '#/components/schemas/Creditors-voluntary-liquidation'
+          compulsory-liquidation: '#/components/schemas/Compulsory-liquidation'
+          receiver-manager: '#/components/schemas/Receiver-manager'
+          administrative-receiver: '#/components/schemas/Administrative-receiver'
+          administration-order: '#/components/schemas/Administration-order'
+          corporate-voluntary-arrangement: '#/components/schemas/Corporate-voluntary-arrangement'
+          in-administration: '#/components/schemas/In-administration'
+          corporate-voluntary-arrangement-moratorium: '#/components/schemas/Corporate-voluntary-arrangement-moratorium'
+          foreign-insolvency: '#/components/schemas/Foreign-insolvency'
+          moratorium: '#/components/schemas/Moratorium'
+    Members-voluntary-liquidation:
+      allOf:
+      - $ref: '#/components/schemas/CommonModelFields'
+      - type: object
+        properties:
+          wind_up_date:
+            type: string
+          dissolved_date:
+            type: string
+          dissolved_due_date:
+            type: string
+          sworn_date:
+            type: string
+    Creditors-voluntary-liquidation:
+      allOf:
+      - $ref: '#/components/schemas/CommonModelFields'
+      - type: object
+        properties:
+          wind_up_date:
+            type: string
+          dissolved_date:
+            type: string
+          dissolved_due_date:
+            type: string
+    Compulsory-liquidation:
+      allOf:
+      - $ref: '#/components/schemas/CommonModelFields'
+    Receiver-manager:
+      allOf:
+      - $ref: '#/components/schemas/CommonModelFields'
+      - type: object
+        properties:
+          instrument_date:
+            type: string
+    Administrative-receiver:
+      allOf:
+      - $ref: '#/components/schemas/CommonModelFields'
+    Administration-order:
+      allOf:
+      - $ref: '#/components/schemas/CommonModelFields'
+      - type: object
+        properties:
+          admin_order_date:
+            type: string
+          discharge_admin_order_date:
+            type: string
+    Corporate-voluntary-arrangement:
+      allOf:
+      - $ref: '#/components/schemas/CommonModelFields'
+      - type: object
+        properties:
+          report_date:
+            type: string
+          completion_date:
+            type: string
+    In-administration:
+      allOf:
+      - $ref: '#/components/schemas/CommonModelFields'
+      - type: object
+        properties:
+          admin_start_date:
+            type: string
+          admin_end_date:
+            type: string
+    Corporate-voluntary-arrangement-moratorium:
+      allOf:
+      - $ref: '#/components/schemas/CommonModelFields'
+      - type: object
+        properties:
+          appointment_date:
+            type: string
+          end_date:
+            type: string
+    Foreign-insolvency:
+      allOf:
+      - $ref: '#/components/schemas/CommonModelFields'
+      - type: object
+    Moratorium:
+      allOf:
+      - $ref: '#/components/schemas/CommonModelFields'
+      - type: object
+        properties:
+          appointment_date:
+            type: string
+          end_date:
+            type: string

--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -1,0 +1,157 @@
+post:
+  summary: Accepts an incoming insolvency delta, transforms it into an avro schema and puts it onto a Kafka topic.
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - $ref: '#/components/schemas/Insolvency_delta_compulsory_liq'
+            - $ref: '#/components/schemas/Insolvency_delta_creditors-voluntary-liq'
+            - ...
+          discriminator:
+            propertyName: case_type
+            mapping:
+              compulsory-liquidation: '#/components/schemas/Insolvency_delta_compulsory_liq'
+              creditors-voluntary-liquidation: '#/components/schemas/Insolvency_delta_creditors-voluntary-liq'
+
+  responses:
+    '200':
+      description: Successfully produced message onto Kafka topic.
+    '400':
+      description: Bad request body - validation errors.
+    '401':
+      description: Unauthorised - missing api key in header.
+    '500':
+      description: Internal server error has occured.
+
+components:
+  schemas:
+    CommonModelFields:
+      type: object
+      properties:
+        title: # fixed string
+          type: string
+        company_number:
+          type: string
+          maxLength: 10
+        case_numbers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Case_number_array'
+        case_type_id:
+          type: number
+          enum:
+            - 1
+            - 2
+            - 3
+            - 5
+            - 6
+            - 7
+            - 8
+            - 13
+            - 14
+            - 15
+            - 17
+
+
+    Insolvency_delta_compulsory_liq:
+      allOf:     # Combines the CommonModelFields and the inline case type specific model
+        - $ref: '#/components/schemas/CommonModelFields'
+        - type: object
+          properties:
+              case_type:
+                type: string
+              wind_up_date:
+                type: string
+              petition_date:
+                type: string
+              wind_up_conclusion_date: 
+                type: string
+              dissolved_date:
+                type: string
+              dissolved_due_date:
+                type: string
+          required:
+            - case_type
+    
+    Insolvency_delta_creditors-voluntary-liq:
+      allOf:     # Combines the CommonModelFields and the inline case type specific model
+        - $ref: '#/components/schemas/CommonModelFields'
+        - type: object
+          properties:
+              case_type:
+                type: string
+              wind_up_date:
+                type: string
+              dissolved_date:
+                type: string
+              dissolved_due_date:
+                type: string
+          required:
+            - case_type
+
+
+        
+
+
+
+
+
+    Insolvency_delta:
+      type: object
+      properties:
+        
+        case_type:
+          type: string
+          enum:
+            - "Members Voluntary Liquidation"
+            - "Creditors Voluntary Liquidation"
+            - "Compulsory Liquidation"
+            - "Official Receiver"
+            - "Receiver/Manager"
+            - "Administrative Receiver"
+            - "Administration"
+            - "Corporate Voluntary Arrangement"
+            - "Declaration of solvency"
+            - "Dummy"
+            - "Liquidation - 'Stay'"
+            - "Provisional Liquidator"
+            - "In Administration"
+            - "CVA Moratoria"
+            - "Foreign Insolvency"
+            - "Administrative Receiver - court"
+            - "Moratorium"
+        wind_up_date:
+          type: string
+        petition_date:
+          type: string
+        wind_up_conclusion_date: 
+          type: string
+        dissolved_date:
+          type: string
+        dissolved_due_date:
+          type: string
+        sworn_date:
+          type: string
+        admin_start_date:
+          type: string
+        admin_end_date:
+          type: string
+        report_date:
+          type: string
+        completion_date:
+          type: string
+        appointment_date:
+          type: string
+        end_date:
+          type: string
+        admin_order_date:
+          type: string
+        discharge_admin_order_date:
+          type: string
+        instrument_date:
+          type: string
+
+
+

--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -32,8 +32,9 @@ components:
         case_numbers:
           type: array
           items:
-            $ref: '#/components/schemas/Case-number'
-    Case-number:
+            $ref: '#/components/schemas/CaseNumber'
+
+    CaseNumber:
       required:
       - case_number
       - case_type_id
@@ -134,8 +135,9 @@ components:
         ceased_to_act_appt:
           type: string
         practitioner_address:
-          $ref: '#/components/schemas/Practitioner-address'
-    Practitioner-address:
+          $ref: '#/components/schemas/PractitionerAddress'
+
+    PractitionerAddress:
       type: object
       properties:
         address_line_1:

--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -76,13 +76,14 @@ components:
                 'Receiver/Manager',
                 'Administrative Receiver',
                 'Administration',
-                'Corporate Voluntary Arrangement',
+                'Corporate Voluntary Arrangement ',
                 'In Administration',
                 'CVA Moratoria',
                 'Foreign Insolvency',
                 'Moratorium']
         mortgage_id:
           type: integer
+          format: int64
         appointments:
           type: array
           items:

--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -4,7 +4,7 @@ post:
     content:
       application/json:
         schema:
-          $ref: '#/components/schemas/Insolvency'
+          $ref: '#/components/schemas/Insolvencies'
     required: true
   responses:
     "200":
@@ -15,17 +15,28 @@ post:
       description: Unauthorised - missing api key in header.
     "500":
       description: Internal server error has occured.
+
 components:
   schemas:
-    Insolvency:
+    Insolvencies:
+      required: 
+      - insolvency
+      type: object
+      properties:
+        insolvency:
+          type: array
+          items:
+            $ref: '#/components/schemas/InsolvencyDelta'
+
+    InsolvencyDelta:
       required:
+      - delta_at
       - company_number
       - case_numbers
       type: object
       properties:
-        title:
+        delta_at:
           type: string
-          enum: ['insolvency']
         company_number:
           maxLength: 10
           type: string
@@ -67,7 +78,7 @@ components:
                 'Administration',
                 'Corporate Voluntary Arrangement',
                 'In Administration',
-                'CVA Moratorium',
+                'CVA Moratoria',
                 'Foreign Insolvency',
                 'Moratorium']
         mortgage_id:

--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -4,7 +4,7 @@ post:
     content:
       application/json:
         schema:
-          $ref: '#/components/schemas/CommonModelFields'
+          $ref: '#/components/schemas/Insolvency'
     required: true
   responses:
     "200":
@@ -17,18 +17,33 @@ post:
       description: Internal server error has occured.
 components:
   schemas:
-    CommonModelFields:
+    Insolvency:
       required:
-      - case_type
+      - company_number
+      - case_numbers
       type: object
       properties:
         title:
           type: string
+          enum: ['insolvency']
         company_number:
           maxLength: 10
           type: string
+        case_numbers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Case-number'
+    Case-number:
+      required:
+      - case_number
+      - case_type_id
+      - case_type
+      type: object
+      properties:
+        case_number:
+          type: integer
         case_type_id:
-          type: number
+          type: integer
           enum:
           - 1
           - 2
@@ -43,103 +58,102 @@ components:
           - 17
         case_type:
           type: string
-      discriminator:
-        propertyName: case_type
-        mapping:
-          members-voluntary-liquidation: '#/components/schemas/Members-voluntary-liquidation'
-          creditors-voluntary-liquidation: '#/components/schemas/Creditors-voluntary-liquidation'
-          compulsory-liquidation: '#/components/schemas/Compulsory-liquidation'
-          receiver-manager: '#/components/schemas/Receiver-manager'
-          administrative-receiver: '#/components/schemas/Administrative-receiver'
-          administration-order: '#/components/schemas/Administration-order'
-          corporate-voluntary-arrangement: '#/components/schemas/Corporate-voluntary-arrangement'
-          in-administration: '#/components/schemas/In-administration'
-          corporate-voluntary-arrangement-moratorium: '#/components/schemas/Corporate-voluntary-arrangement-moratorium'
-          foreign-insolvency: '#/components/schemas/Foreign-insolvency'
-          moratorium: '#/components/schemas/Moratorium'
-    Members-voluntary-liquidation:
-      allOf:
-      - $ref: '#/components/schemas/CommonModelFields'
-      - type: object
-        properties:
-          wind_up_date:
-            type: string
-          dissolved_date:
-            type: string
-          dissolved_due_date:
-            type: string
-          sworn_date:
-            type: string
-    Creditors-voluntary-liquidation:
-      allOf:
-      - $ref: '#/components/schemas/CommonModelFields'
-      - type: object
-        properties:
-          wind_up_date:
-            type: string
-          dissolved_date:
-            type: string
-          dissolved_due_date:
-            type: string
-    Compulsory-liquidation:
-      allOf:
-      - $ref: '#/components/schemas/CommonModelFields'
-    Receiver-manager:
-      allOf:
-      - $ref: '#/components/schemas/CommonModelFields'
-      - type: object
-        properties:
-          instrument_date:
-            type: string
-    Administrative-receiver:
-      allOf:
-      - $ref: '#/components/schemas/CommonModelFields'
-    Administration-order:
-      allOf:
-      - $ref: '#/components/schemas/CommonModelFields'
-      - type: object
-        properties:
-          admin_order_date:
-            type: string
-          discharge_admin_order_date:
-            type: string
-    Corporate-voluntary-arrangement:
-      allOf:
-      - $ref: '#/components/schemas/CommonModelFields'
-      - type: object
-        properties:
-          report_date:
-            type: string
-          completion_date:
-            type: string
-    In-administration:
-      allOf:
-      - $ref: '#/components/schemas/CommonModelFields'
-      - type: object
-        properties:
-          admin_start_date:
-            type: string
-          admin_end_date:
-            type: string
-    Corporate-voluntary-arrangement-moratorium:
-      allOf:
-      - $ref: '#/components/schemas/CommonModelFields'
-      - type: object
-        properties:
-          appointment_date:
-            type: string
-          end_date:
-            type: string
-    Foreign-insolvency:
-      allOf:
-      - $ref: '#/components/schemas/CommonModelFields'
-      - type: object
-    Moratorium:
-      allOf:
-      - $ref: '#/components/schemas/CommonModelFields'
-      - type: object
-        properties:
-          appointment_date:
-            type: string
-          end_date:
-            type: string
+          enum: ['Members Voluntary Liquidation',
+                'Creditors Voluntary Liquidation',
+                'Compulsory Liquidation',
+                'Receiver Manager',
+                'Administrative Receiver',
+                'Administration',
+                'Corporate Voluntary Arrangement',
+                'In Administration',
+                'Corporate Voluntary Arrangement Moratorium',
+                'Foreign Insolvency',
+                'Moratorium']
+        mortgage_id:
+          type: integer
+        appointments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Appointment'
+        wind_up_date:
+          type: string
+        dissolved_date:
+          type: string
+        dissolved_due_date:
+          type: string
+        sworn_date:
+          type: string
+        petition_date:
+          type: string
+        wind_up_conclusion_date:
+          type: string 
+        instrument_date:
+          type: string
+        admin_order_date:
+          type: string
+        discharge_admin_order_date:
+          type: string
+        report_date:
+          type: string
+        completion_date:
+          type: string
+        admin_start_date:
+          type: string
+        admin_end_date:
+          type: string
+        appointment_date:
+          type: string
+        end_date:
+          type: string
+
+   
+    Appointment:
+      type: object
+      properties:
+        forename:
+          type: string
+          maxLength: 50
+        middle_name:
+          type: string
+          maxLength: 50
+        surname:
+          type: string
+          maxLength: 160
+        appt_type:
+          type: integer
+          enum:
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+        appt_date:
+          type: string
+        ceased_to_act_appt:
+          type: string
+        practitioner_address:
+          $ref: '#/components/schemas/Practitioner-address'
+    Practitioner-address:
+      type: object
+      properties:
+        address_line_1:
+          type: string
+          maxLength: 50
+        address_line_2:
+          type: string
+          maxLength: 50
+        locality:
+          type: string
+          maxLength: 50
+        region:
+          type: string
+          maxLength: 50
+        country:
+          type: string
+          maxLength: 50
+        postal_code:
+          type: string
+          maxLength: 20

--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -61,12 +61,12 @@ components:
           enum: ['Members Voluntary Liquidation',
                 'Creditors Voluntary Liquidation',
                 'Compulsory Liquidation',
-                'Receiver Manager',
+                'Receiver/Manager',
                 'Administrative Receiver',
                 'Administration',
                 'Corporate Voluntary Arrangement',
                 'In Administration',
-                'Corporate Voluntary Arrangement Moratorium',
+                'CVA Moratorium',
                 'Foreign Insolvency',
                 'Moratorium']
         mortgage_id:
@@ -106,7 +106,6 @@ components:
         end_date:
           type: string
 
-   
     Appointment:
       type: object
       properties:

--- a/config/config.go
+++ b/config/config.go
@@ -3,9 +3,10 @@ package config
 
 import (
 	"errors"
+	"sync"
+
 	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/gofigure"
-	"sync"
 )
 
 var (
@@ -16,11 +17,11 @@ var (
 
 // Config defines the configuration options for this service.
 type Config struct {
-	BindAddr          string   `env:"BIND_ADDR" flag:"bind-addr" flagDesc:"Bind address"`
-	BrokerAddr        []string `env:"KAFKA_BROKER_ADDR" flag:"broker-addr" flagDesc:"Kafka broker address (Comma separated list if there is more than one address)"`
-	SchemaRegistryURL string   `env:"SCHEMA_REGISTRY_URL" flag:"schema-registry-url" flagDesc:"URL for Kafka Schema Registry"`
-	OfficerDeltaTopic string   `env:"OFFICER_DELTA_TOPIC" flag:"officer-delta-topic" flagDesc:"Topic for officer deltas"`
-	OpenApiSpec       string   `env:"OPEN_API_SPEC" flag:"open-api-spec" flagDesc:"OpenAPI schema location"`
+	BindAddr             string   `env:"BIND_ADDR" flag:"bind-addr" flagDesc:"Bind address"`
+	BrokerAddr           []string `env:"KAFKA_BROKER_ADDR" flag:"broker-addr" flagDesc:"Kafka broker address (Comma separated list if there is more than one address)"`
+	SchemaRegistryURL    string   `env:"SCHEMA_REGISTRY_URL" flag:"schema-registry-url" flagDesc:"URL for Kafka Schema Registry"`
+	OfficerDeltaTopic    string   `env:"OFFICER_DELTA_TOPIC" flag:"officer-delta-topic" flagDesc:"Topic for officer deltas"`
+	OpenApiSpec          string   `env:"OPEN_API_SPEC" flag:"open-api-spec" flagDesc:"OpenAPI schema location"`
 	InsolvencyDeltaTopic string   `env:"INSOLVENCY_DELTA_TOPIC" flag:"insolvency-delta-topic" flagDesc:"Topic for insolvency deltas"`
 }
 
@@ -69,6 +70,11 @@ func validateConfigs(cfg *Config) error {
 
 	if cfg.OfficerDeltaTopic == "" {
 		log.Info("OFFICER_DELTA_TOPIC not set in environment")
+		mandatoryElementMissing = true
+	}
+
+	if cfg.InsolvencyDeltaTopic == "" {
+		log.Info("INSOLVENCY_DELTA_TOPIC not set in environment")
 		mandatoryElementMissing = true
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	SchemaRegistryURL string   `env:"SCHEMA_REGISTRY_URL" flag:"schema-registry-url" flagDesc:"URL for Kafka Schema Registry"`
 	OfficerDeltaTopic string   `env:"OFFICER_DELTA_TOPIC" flag:"officer-delta-topic" flagDesc:"Topic for officer deltas"`
 	OpenApiSpec       string   `env:"OPEN_API_SPEC" flag:"open-api-spec" flagDesc:"OpenAPI schema location"`
+	InsolvencyDeltaTopic string   `env:"INSOLVENCY_DELTA_TOPIC" flag:"insolvency-delta-topic" flagDesc:"Topic for insolvency deltas"`
 }
 
 // Get returns a pointer to a Config instance populated with values from environment or command-line flags

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,9 +1,10 @@
 package config
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"os"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestUnitGetHasErrors(t *testing.T) {
@@ -21,6 +22,7 @@ func TestUnitGetNoErrors(t *testing.T) {
 	_ = os.Setenv("KAFKA_BROKER_ADDR", "kafka_broker_addr,kafka_broker_addr")
 	_ = os.Setenv("SCHEMA_REGISTRY_URL", "schema_registry_url")
 	_ = os.Setenv("OFFICER_DELTA_TOPIC", "officer_delta_topic")
+	_ = os.Setenv("INSOLVENCY_DELTA_TOPIC", "insolvency_delta_topic")
 	_ = os.Setenv("OPEN_API_SPEC", "open_api_spec")
 	Convey("When I try to get the config via the Get method and all config vars are provided", t, func() {
 		cfg, err := Get()

--- a/docs/adding-a-new-delta.md
+++ b/docs/adding-a-new-delta.md
@@ -28,7 +28,7 @@ ExampleDeltaTopic string `env:"EXAMPLE_DELTA_TOPIC" flag:"example-delta-topic" f
 ```
 
 ## 3. Exposing your new delta endpoint
-The final step of adding a new delta is to register your new route within the `register.go` file.
+You need to register your new route within the `register.go` file.
 ```go
 appRouter.HandleFunc("/delta/example-delta", NewDeltaHandler(kSvc, h, chv, cfg, false, cfg.ExampleDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("example-delta")
 ```
@@ -40,6 +40,21 @@ appRouter.HandleFunc("/delta/example-delta/validate", NewDeltaHandler(kSvc, h, c
 ```
 
 Finally, you'll need to update the register.go `TestUnitRegister` unit test to cover your changes.
+
+## 4. Updating docker compose to specify your kafka topic
+In order to run this you need to have added a new environment variable in the respective docker compose file located in the [docker-chs-development repo](https://github.com/companieshouse/docker-chs-development). For deltas this is `services/modules/delta/chs-delta-api.docker-compose.yaml`. 
+
+Add your kafka topic name under `services.chs-delta-api.environment` like so:
+
+```yaml
+services:
+  chs-delta-api:
+    ...
+    environment:
+      ...
+      - EXAMPLE_DELTA_TOPIC=example-delta
+      ...
+```
 
 ## Final notes
 All other services on the chs-delta-api are generic and will not require any changes when adding a new delta, including 

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -47,7 +47,8 @@ func Register(mainRouter *mux.Router, cfg *config.Config, kSvc services.KafkaSer
 	appRouter.HandleFunc("/delta/officers", NewDeltaHandler(kSvc, h, chv, cfg, false, cfg.OfficerDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("officer-delta")
 	appRouter.HandleFunc("/delta/officers/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, cfg.OfficerDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("officer-delta-validate")
 	appRouter.Use(userAuthInterceptor.UserAuthenticationIntercept)
-
+	appRouter.HandleFunc("/delta/insolvency", NewDeltaHandler(kSvc, h, chv, cfg, false, cfg.InsolvencyDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("insolvency-delta")
+	appRouter.HandleFunc("/delta/insolvency/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, cfg.InsolvencyDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("insolvency-delta-validate")
 	return nil
 }
 

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -2,13 +2,13 @@
 package handlers
 
 import (
+	"net/http"
+
 	"github.com/companieshouse/chs-delta-api/config"
 	"github.com/companieshouse/chs-delta-api/helpers"
 	"github.com/companieshouse/chs-delta-api/services"
 	"github.com/companieshouse/chs-delta-api/validation"
 	"github.com/companieshouse/chs.go/authentication"
-	"net/http"
-
 	"github.com/companieshouse/chs.go/log"
 	"github.com/gorilla/mux"
 )
@@ -46,9 +46,9 @@ func Register(mainRouter *mux.Router, cfg *config.Config, kSvc services.KafkaSer
 	appRouter := mainRouter.PathPrefix("").Subrouter()
 	appRouter.HandleFunc("/delta/officers", NewDeltaHandler(kSvc, h, chv, cfg, false, cfg.OfficerDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("officer-delta")
 	appRouter.HandleFunc("/delta/officers/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, cfg.OfficerDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("officer-delta-validate")
-	appRouter.Use(userAuthInterceptor.UserAuthenticationIntercept)
 	appRouter.HandleFunc("/delta/insolvency", NewDeltaHandler(kSvc, h, chv, cfg, false, cfg.InsolvencyDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("insolvency-delta")
 	appRouter.HandleFunc("/delta/insolvency/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, cfg.InsolvencyDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("insolvency-delta-validate")
+	appRouter.Use(userAuthInterceptor.UserAuthenticationIntercept)
 	return nil
 }
 

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -1,14 +1,15 @@
 package handlers
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/companieshouse/chs-delta-api/config"
 	"github.com/companieshouse/chs-delta-api/services/mocks"
 	"github.com/companieshouse/chs-delta-api/validation"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -48,33 +49,8 @@ func TestUnitRegister(t *testing.T) {
 		So(router.GetRoute("officer-delta"), ShouldNotBeNil)
 		So(router.GetRoute("officer-delta-validate"), ShouldNotBeNil)
 		So(err, ShouldBeNil)
-	})
-
-	// TestUnitRegister asserts that all routes are correctly registered and can be called.
-func TestUnitRegister(t *testing.T) {
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	Convey("When we call the register function then all routes are registered", t, func() {
-		router := mux.NewRouter()
-
-		callNewCHValidator = func(openApiSpec string) (validation.CHValidator, error) {
-			return &validation.CHValidatorImpl{}, nil
-		}
-
-		config.CallValidateConfig = func(cfg *config.Config) error {
-			return nil
-		}
-		cfg, _ := config.Get()
-		kSvc := mocks.NewMockKafkaService(mockCtrl)
-
-		kSvc.EXPECT().Init(cfg).Return(nil)
-
-		err := Register(router, cfg, kSvc)
-		So(router.GetRoute("healthcheck"), ShouldNotBeNil)
 		So(router.GetRoute("insolvency-delta"), ShouldNotBeNil)
 		So(router.GetRoute("insolvency-delta-validate"), ShouldNotBeNil)
-		So(err, ShouldBeNil)
 	})
+
 }

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -49,4 +49,32 @@ func TestUnitRegister(t *testing.T) {
 		So(router.GetRoute("officer-delta-validate"), ShouldNotBeNil)
 		So(err, ShouldBeNil)
 	})
+
+	// TestUnitRegister asserts that all routes are correctly registered and can be called.
+func TestUnitRegister(t *testing.T) {
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	Convey("When we call the register function then all routes are registered", t, func() {
+		router := mux.NewRouter()
+
+		callNewCHValidator = func(openApiSpec string) (validation.CHValidator, error) {
+			return &validation.CHValidatorImpl{}, nil
+		}
+
+		config.CallValidateConfig = func(cfg *config.Config) error {
+			return nil
+		}
+		cfg, _ := config.Get()
+		kSvc := mocks.NewMockKafkaService(mockCtrl)
+
+		kSvc.EXPECT().Init(cfg).Return(nil)
+
+		err := Register(router, cfg, kSvc)
+		So(router.GetRoute("healthcheck"), ShouldNotBeNil)
+		So(router.GetRoute("insolvency-delta"), ShouldNotBeNil)
+		So(router.GetRoute("insolvency-delta-validate"), ShouldNotBeNil)
+		So(err, ShouldBeNil)
+	})
 }

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -48,9 +48,9 @@ func TestUnitRegister(t *testing.T) {
 		So(router.GetRoute("healthcheck"), ShouldNotBeNil)
 		So(router.GetRoute("officer-delta"), ShouldNotBeNil)
 		So(router.GetRoute("officer-delta-validate"), ShouldNotBeNil)
-		So(err, ShouldBeNil)
 		So(router.GetRoute("insolvency-delta"), ShouldNotBeNil)
 		So(router.GetRoute("insolvency-delta-validate"), ShouldNotBeNil)
+		So(err, ShouldBeNil)
 	})
 
 }

--- a/validation/chOpenApiValidator.go
+++ b/validation/chOpenApiValidator.go
@@ -5,6 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+
 	"github.com/companieshouse/chs-delta-api/config"
 	"github.com/companieshouse/chs-delta-api/models"
 	"github.com/companieshouse/chs.go/log"
@@ -12,9 +16,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/getkin/kin-openapi/routers"
 	router "github.com/getkin/kin-openapi/routers/gorillamux"
-	"net/http"
-	"path/filepath"
-	"strings"
 )
 
 const (
@@ -98,7 +99,7 @@ func (chv CHValidatorImpl) ValidateRequestAgainstOpenApiSpec(httpReq *http.Reque
 	}
 
 	// Switch off the addition of schema error details to the returned error. This stops the OpenApi schema being added to errors.
-	openapi3.SchemaErrorDetailsDisabled = true
+	openapi3.SchemaErrorDetailsDisabled = false
 
 	log.InfoC(contextId, "Validating request using: ", log.Data{config.OpenApiSpecKey: chv.openApiSpec})
 	if err := callOpenApiFilterValidateRequest(ctx, requestValidationInput); err != nil {

--- a/validation/chOpenApiValidator.go
+++ b/validation/chOpenApiValidator.go
@@ -99,7 +99,7 @@ func (chv CHValidatorImpl) ValidateRequestAgainstOpenApiSpec(httpReq *http.Reque
 	}
 
 	// Switch off the addition of schema error details to the returned error. This stops the OpenApi schema being added to errors.
-	openapi3.SchemaErrorDetailsDisabled = false
+	openapi3.SchemaErrorDetailsDisabled = true
 
 	log.InfoC(contextId, "Validating request using: ", log.Data{config.OpenApiSpecKey: chv.openApiSpec})
 	if err := callOpenApiFilterValidateRequest(ctx, requestValidationInput); err != nil {

--- a/validation/schema_testing/insolvency/insolvencyDeltaSchema.go
+++ b/validation/schema_testing/insolvency/insolvencyDeltaSchema.go
@@ -1,0 +1,1 @@
+package insolvency

--- a/validation/schema_testing/insolvency/insolvencyDeltaSchema_test.go
+++ b/validation/schema_testing/insolvency/insolvencyDeltaSchema_test.go
@@ -1,0 +1,134 @@
+package insolvency
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/companieshouse/chs-delta-api/validation"
+	"github.com/companieshouse/chs-delta-api/validation/schema_testing/common"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	requestBodiesLocation            = "./request_bodies/"
+	okRequestBodyLocation            = requestBodiesLocation + "ok_request_body"
+	typeErrorRequestBodyLocation     = requestBodiesLocation + "type_error_request_body"
+	requiredErrorRequestBodyLocation = requestBodiesLocation + "required_error_request_body"
+
+	responseBodiesLocation                 = "./response_bodies/"
+	typeErrorResponseBodyLocation          = responseBodiesLocation + "type_error_response_body"
+	requiredErrorResponseBodyLocation      = responseBodiesLocation + "required_error_response_body"
+	noRequestBodyErrorResponseBodyLocation = responseBodiesLocation + "no_request_body_error_response_body"
+
+	insolvencyEndpoint = "/delta/insolvency"
+	apiSpecLocation    = "../../../apispec/api-spec.yml"
+	contextId          = "contextId"
+	methodPost         = "POST"
+)
+
+// TestUnitInsolvencyDeltaSchemaNoErrors asserts that when a valid request body is given which matches the schema, then no
+// errors are returned.
+func TestUnitInsolvencyDeltaSchemaNoErrors(t *testing.T) {
+
+	Convey("Given I want to test the insolvency-delta API schema", t, func() {
+
+		okRequestBody := common.ReadRequestBody(okRequestBodyLocation)
+
+		r := httptest.NewRequest(methodPost, insolvencyEndpoint, bytes.NewBuffer(okRequestBody))
+		r = common.SetHeaders(r)
+
+		Convey("When I call to validate the request body, providing a valid request", func() {
+
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
+
+			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, contextId)
+
+			Convey("Then I am given a nil response as no validation errors are returned", func() {
+				So(validationErrs, ShouldBeNil)
+			})
+		})
+	})
+}
+
+// TestUnitInsolvencyDeltaSchemaTypeErrors asserts that when an invalid request body is given with type errors (int provided
+// instead of string), then an errors array is returned.
+func TestUnitInsolvencyDeltaSchemaTypeErrors(t *testing.T) {
+
+	Convey("Given I want to test the insolvency-delta API schema for type assertions", t, func() {
+
+		typeErrorRequestBody := common.ReadRequestBody(typeErrorRequestBodyLocation)
+
+		r := httptest.NewRequest(methodPost, insolvencyEndpoint, bytes.NewBuffer(typeErrorRequestBody))
+		r = common.SetHeaders(r)
+
+		Convey("When I call to validate the request body, providing an valid request with type errors", func() {
+
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
+
+			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, contextId)
+
+			Convey("Then I am given an errors array response as validation errors have been found", func() {
+				typeErrorResponseBody := common.ReadRequestBody(typeErrorResponseBodyLocation)
+				match := common.CompareActualToExpected(validationErrs, typeErrorResponseBody)
+
+				So(validationErrs, ShouldNotBeNil)
+				So(match, ShouldEqual, true)
+			})
+		})
+	})
+}
+
+// TestUnitInsolvencyDeltaSchemaRequiredErrors asserts that when an invalid request body is given with missing mandatory values.
+// then an errors array is returned, stating that required values are missing.
+func TestUnitInsolvencyDeltaSchemaRequiredErrors(t *testing.T) {
+
+	Convey("Given I want to test the insolvency-delta API schema to assert mandatory validation is working correctly", t, func() {
+
+		mandatoryErrorsRequestBody := common.ReadRequestBody(requiredErrorRequestBodyLocation)
+
+		r := httptest.NewRequest(methodPost, insolvencyEndpoint, bytes.NewBuffer(mandatoryErrorsRequestBody))
+		r = common.SetHeaders(r)
+
+		Convey("When I call to validate the request body, providing an valid request with missing mandatory values", func() {
+
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
+
+			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, contextId)
+
+			Convey("Then I am given an errors array response as validation errors have been found", func() {
+				mandatoryErrorsResponseBody := common.ReadRequestBody(requiredErrorResponseBodyLocation)
+				match := common.CompareActualToExpected(validationErrs, mandatoryErrorsResponseBody)
+
+				So(validationErrs, ShouldNotBeNil)
+				So(match, ShouldEqual, true)
+			})
+		})
+	})
+}
+
+// TestUnitInsolvencyDeltaSchemaNoRequestBodyError asserts that when a missing request body is given,
+// then an error is returned, stating that request body is missing.
+func TestUnitInsolvencyDeltaSchemaNoRequestBodyError(t *testing.T) {
+
+	Convey("Given I want to test the insolvency-delta API schema to assert validation is working correctly", t, func() {
+
+		r := httptest.NewRequest(methodPost, insolvencyEndpoint, bytes.NewBuffer(nil))
+		r = common.SetHeaders(r)
+
+		Convey("When I call to validate the request body, providing an empty request body", func() {
+
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
+
+			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, contextId)
+
+			Convey("Then I am given an error saying no request body provided", func() {
+				noRequestBodyErrorsResponseBody := common.ReadRequestBody(noRequestBodyErrorResponseBodyLocation)
+				match := common.CompareActualToExpected(validationErrs, noRequestBodyErrorsResponseBody)
+
+				So(validationErrs, ShouldNotBeNil)
+				So(match, ShouldEqual, true)
+			})
+		})
+	})
+}

--- a/validation/schema_testing/insolvency/request_bodies/ok_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/ok_request_body
@@ -1,0 +1,45 @@
+{
+  "title": "insolvency",
+  "company_number": "string",
+  "case_numbers": [
+    {
+      "case_number": 0,
+      "case_type_id": 1,
+      "case_type": "Members Voluntary Liquidation",
+      "mortgage_id": 0,
+      "appointments": [
+        {
+          "forename": "string",
+          "middle_name": "string",
+          "surname": "string",
+          "appt_type": 1,
+          "appt_date": "string",
+          "ceased_to_act_appt": "string",
+          "practitioner_address": {
+            "address_line_1": "string",
+            "address_line_2": "string",
+            "locality": "string",
+            "region": "string",
+            "country": "string",
+            "postal_code": "string"
+          }
+        }
+      ],
+      "wind_up_date": "string",
+      "dissolved_date": "string",
+      "dissolved_due_date": "string",
+      "sworn_date": "string",
+      "petition_date": "string",
+      "wind_up_conclusion_date": "string",
+      "instrument_date": "string",
+      "admin_order_date": "string",
+      "discharge_admin_order_date": "string",
+      "report_date": "string",
+      "completion_date": "string",
+      "admin_start_date": "string",
+      "admin_end_date": "string",
+      "appointment_date": "string",
+      "end_date": "string"
+    }
+  ]
+}

--- a/validation/schema_testing/insolvency/request_bodies/ok_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/ok_request_body
@@ -1,45 +1,49 @@
 {
-  "title": "insolvency",
-  "company_number": "string",
-  "case_numbers": [
+  "insolvency": [
     {
-      "case_number": 0,
-      "case_type_id": 1,
-      "case_type": "Members Voluntary Liquidation",
-      "mortgage_id": 0,
-      "appointments": [
+      "delta_at": "20211008152823383176",
+      "company_number": "string",
+      "case_numbers": [
         {
-          "forename": "string",
-          "middle_name": "string",
-          "surname": "string",
-          "appt_type": 1,
-          "appt_date": "string",
-          "ceased_to_act_appt": "string",
-          "practitioner_address": {
-            "address_line_1": "string",
-            "address_line_2": "string",
-            "locality": "string",
-            "region": "string",
-            "country": "string",
-            "postal_code": "string"
-          }
+          "case_number": 0,
+          "case_type_id": 1,
+          "case_type": "Members Voluntary Liquidation",
+          "mortgage_id": 0,
+          "appointments": [
+            {
+              "forename": "string",
+              "middle_name": "string",
+              "surname": "string",
+              "appt_type": 1,
+              "appt_date": "string",
+              "ceased_to_act_appt": "string",
+              "practitioner_address": {
+                "address_line_1": "string",
+                "address_line_2": "string",
+                "locality": "string",
+                "region": "string",
+                "country": "string",
+                "postal_code": "string"
+              }
+            }
+          ],
+          "wind_up_date": "string",
+          "dissolved_date": "string",
+          "dissolved_due_date": "string",
+          "sworn_date": "string",
+          "petition_date": "string",
+          "wind_up_conclusion_date": "string",
+          "instrument_date": "string",
+          "admin_order_date": "string",
+          "discharge_admin_order_date": "string",
+          "report_date": "string",
+          "completion_date": "string",
+          "admin_start_date": "string",
+          "admin_end_date": "string",
+          "appointment_date": "string",
+          "end_date": "string"
         }
-      ],
-      "wind_up_date": "string",
-      "dissolved_date": "string",
-      "dissolved_due_date": "string",
-      "sworn_date": "string",
-      "petition_date": "string",
-      "wind_up_conclusion_date": "string",
-      "instrument_date": "string",
-      "admin_order_date": "string",
-      "discharge_admin_order_date": "string",
-      "report_date": "string",
-      "completion_date": "string",
-      "admin_start_date": "string",
-      "admin_end_date": "string",
-      "appointment_date": "string",
-      "end_date": "string"
+      ]
     }
   ]
 }

--- a/validation/schema_testing/insolvency/request_bodies/required_error_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/required_error_request_body
@@ -1,0 +1,41 @@
+{
+  "title": "insolvency",
+  "case_numbers": [
+    {
+      "mortgage_id": 0,
+      "appointments": [
+        {
+          "forename": "string",
+          "middle_name": "string",
+          "surname": "string",
+          "appt_type": 1,
+          "appt_date": "string",
+          "ceased_to_act_appt": "string",
+          "practitioner_address": {
+            "address_line_1": "string",
+            "address_line_2": "string",
+            "locality": "string",
+            "region": "string",
+            "country": "string",
+            "postal_code": "string"
+          }
+        }
+      ],
+      "wind_up_date": "string",
+      "dissolved_date": "string",
+      "dissolved_due_date": "string",
+      "sworn_date": "string",
+      "petition_date": "string",
+      "wind_up_conclusion_date": "string",
+      "instrument_date": "string",
+      "admin_order_date": "string",
+      "discharge_admin_order_date": "string",
+      "report_date": "string",
+      "completion_date": "string",
+      "admin_start_date": "string",
+      "admin_end_date": "string",
+      "appointment_date": "string",
+      "end_date": "string"
+    }
+  ]
+}

--- a/validation/schema_testing/insolvency/request_bodies/required_error_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/required_error_request_body
@@ -1,41 +1,44 @@
 {
-  "title": "insolvency",
-  "case_numbers": [
+  "insolvency": [
     {
-      "mortgage_id": 0,
-      "appointments": [
+      "case_numbers": [
         {
-          "forename": "string",
-          "middle_name": "string",
-          "surname": "string",
-          "appt_type": 1,
-          "appt_date": "string",
-          "ceased_to_act_appt": "string",
-          "practitioner_address": {
-            "address_line_1": "string",
-            "address_line_2": "string",
-            "locality": "string",
-            "region": "string",
-            "country": "string",
-            "postal_code": "string"
-          }
+          "mortgage_id": 0,
+          "appointments": [
+            {
+              "forename": "string",
+              "middle_name": "string",
+              "surname": "string",
+              "appt_type": 1,
+              "appt_date": "string",
+              "ceased_to_act_appt": "string",
+              "practitioner_address": {
+                "address_line_1": "string",
+                "address_line_2": "string",
+                "locality": "string",
+                "region": "string",
+                "country": "string",
+                "postal_code": "string"
+              }
+            }
+          ],
+          "wind_up_date": "string",
+          "dissolved_date": "string",
+          "dissolved_due_date": "string",
+          "sworn_date": "string",
+          "petition_date": "string",
+          "wind_up_conclusion_date": "string",
+          "instrument_date": "string",
+          "admin_order_date": "string",
+          "discharge_admin_order_date": "string",
+          "report_date": "string",
+          "completion_date": "string",
+          "admin_start_date": "string",
+          "admin_end_date": "string",
+          "appointment_date": "string",
+          "end_date": "string"
         }
-      ],
-      "wind_up_date": "string",
-      "dissolved_date": "string",
-      "dissolved_due_date": "string",
-      "sworn_date": "string",
-      "petition_date": "string",
-      "wind_up_conclusion_date": "string",
-      "instrument_date": "string",
-      "admin_order_date": "string",
-      "discharge_admin_order_date": "string",
-      "report_date": "string",
-      "completion_date": "string",
-      "admin_start_date": "string",
-      "admin_end_date": "string",
-      "appointment_date": "string",
-      "end_date": "string"
+      ]
     }
   ]
 }

--- a/validation/schema_testing/insolvency/request_bodies/type_error_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/type_error_request_body
@@ -1,45 +1,49 @@
 {
-  "title": "invalid",
-  "company_number": 123,
-  "case_numbers": [
+  "insolvency": [
     {
-      "case_number": "invalid",
-      "case_type_id": "invalid",
-      "case_type": "invalid",
-      "mortgage_id": "invalid",
-      "appointments": [
+      "delta_at": 123,
+      "company_number": 123,
+      "case_numbers": [
         {
-          "forename": 123,
-          "middle_name": 123,
-          "surname": 123,
-          "appt_type": 123,
-          "appt_date": 123,
-          "ceased_to_act_appt": 123,
-          "practitioner_address": {
-            "address_line_1": 123,
-            "address_line_2": 123,
-            "locality": 123,
-            "region": 123,
-            "country": 123,
-            "postal_code": 123
-          }
+          "case_number": "invalid",
+          "case_type_id": "invalid",
+          "case_type": "invalid",
+          "mortgage_id": "invalid",
+          "appointments": [
+            {
+              "forename": 123,
+              "middle_name": 123,
+              "surname": 123,
+              "appt_type": 123,
+              "appt_date": 123,
+              "ceased_to_act_appt": 123,
+              "practitioner_address": {
+                "address_line_1": 123,
+                "address_line_2": 123,
+                "locality": 123,
+                "region": 123,
+                "country": 123,
+                "postal_code": 123
+              }
+            }
+          ],
+          "wind_up_date": 123,
+          "dissolved_date": 123,
+          "dissolved_due_date": 123,
+          "sworn_date": 123,
+          "petition_date": 123,
+          "wind_up_conclusion_date": 123,
+          "instrument_date": 123,
+          "admin_order_date": 123,
+          "discharge_admin_order_date": 123,
+          "report_date": 123,
+          "completion_date": 123,
+          "admin_start_date": 123,
+          "admin_end_date": 123,
+          "appointment_date": 123,
+          "end_date": 123
         }
-      ],
-      "wind_up_date": 123,
-      "dissolved_date": 123,
-      "dissolved_due_date": 123,
-      "sworn_date": 123,
-      "petition_date": 123,
-      "wind_up_conclusion_date": 123,
-      "instrument_date": 123,
-      "admin_order_date": 123,
-      "discharge_admin_order_date": 123,
-      "report_date": 123,
-      "completion_date": 123,
-      "admin_start_date": 123,
-      "admin_end_date": 123,
-      "appointment_date": 123,
-      "end_date": 123
+      ]
     }
   ]
 }

--- a/validation/schema_testing/insolvency/request_bodies/type_error_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/type_error_request_body
@@ -1,0 +1,45 @@
+{
+  "title": "invalid",
+  "company_number": 123,
+  "case_numbers": [
+    {
+      "case_number": "invalid",
+      "case_type_id": "invalid",
+      "case_type": "invalid",
+      "mortgage_id": "invalid",
+      "appointments": [
+        {
+          "forename": 123,
+          "middle_name": 123,
+          "surname": 123,
+          "appt_type": 123,
+          "appt_date": 123,
+          "ceased_to_act_appt": 123,
+          "practitioner_address": {
+            "address_line_1": 123,
+            "address_line_2": 123,
+            "locality": 123,
+            "region": 123,
+            "country": 123,
+            "postal_code": 123
+          }
+        }
+      ],
+      "wind_up_date": 123,
+      "dissolved_date": 123,
+      "dissolved_due_date": 123,
+      "sworn_date": 123,
+      "petition_date": 123,
+      "wind_up_conclusion_date": 123,
+      "instrument_date": 123,
+      "admin_order_date": 123,
+      "discharge_admin_order_date": 123,
+      "report_date": 123,
+      "completion_date": 123,
+      "admin_start_date": 123,
+      "admin_end_date": 123,
+      "appointment_date": 123,
+      "end_date": 123
+    }
+  ]
+}

--- a/validation/schema_testing/insolvency/response_bodies/no_request_body_error_response_body
+++ b/validation/schema_testing/insolvency/response_bodies/no_request_body_error_response_body
@@ -1,0 +1,5 @@
+[
+    {
+        "location": "request-body"
+    }
+]

--- a/validation/schema_testing/insolvency/response_bodies/required_error_response_body
+++ b/validation/schema_testing/insolvency/response_bodies/required_error_response_body
@@ -1,14 +1,17 @@
 [
     {
-        "location": "company_number"
+        "location": "insolvency.0.delta_at"
     },
     {
-        "location": "case_numbers.0.case_type"
+        "location": "insolvency.0.company_number"
     },
     {
-        "location": "case_numbers.0.case_type_id"
+        "location": "insolvency.0.case_numbers.0.case_type"
     },
     {
-        "location": "case_numbers.0.case_number"
+        "location": "insolvency.0.case_numbers.0.case_type_id"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.case_number"
     }
 ]

--- a/validation/schema_testing/insolvency/response_bodies/required_error_response_body
+++ b/validation/schema_testing/insolvency/response_bodies/required_error_response_body
@@ -1,0 +1,14 @@
+[
+    {
+        "location": "company_number"
+    },
+    {
+        "location": "case_numbers.0.case_type"
+    },
+    {
+        "location": "case_numbers.0.case_type_id"
+    },
+    {
+        "location": "case_numbers.0.case_number"
+    }
+]

--- a/validation/schema_testing/insolvency/response_bodies/type_error_response_body
+++ b/validation/schema_testing/insolvency/response_bodies/type_error_response_body
@@ -1,0 +1,101 @@
+[
+    {
+        "location": "case_numbers.0.case_number"
+    },
+    {
+        "location": "title"
+    },
+    {
+        "location": "company_number"
+    },
+    {
+        "location": "case_numbers.0.case_type_id"
+    },
+    {
+        "location": "case_numbers.0.case_type"
+    },
+    {
+        "location": "case_numbers.0.mortgage_id"
+    },
+    {
+        "location": "case_numbers.0.appointments.0.forename"
+    },
+    {
+        "location": "case_numbers.0.appointments.0.middle_name"
+    },
+    {
+        "location": "case_numbers.0.appointments.0.surname"
+    },
+    {
+        "location": "case_numbers.0.appointments.0.appt_type"
+    },
+    {
+        "location": "case_numbers.0.appointments.0.appt_date"
+    },
+    {
+        "location": "case_numbers.0.appointments.0.ceased_to_act_appt"
+    },
+    {
+        "location": "case_numbers.0.appointments.0.practitioner_address.address_line_1"
+    },
+    {
+        "location": "case_numbers.0.appointments.0.practitioner_address.address_line_2"
+    },
+    {
+        "location": "case_numbers.0.appointments.0.practitioner_address.locality"
+    },
+    {
+        "location": "case_numbers.0.appointments.0.practitioner_address.region"
+    },
+    {
+        "location": "case_numbers.0.appointments.0.practitioner_address.country"
+    },
+    {
+        "location": "case_numbers.0.appointments.0.practitioner_address.postal_code"
+    },
+    {
+        "location": "case_numbers.0.wind_up_date"
+    },
+    {
+        "location": "case_numbers.0.dissolved_date"
+    },
+    {
+        "location": "case_numbers.0.dissolved_due_date"
+    },
+    {
+        "location": "case_numbers.0.sworn_date"
+    },
+    {
+        "location": "case_numbers.0.petition_date"
+    },
+    {
+        "location": "case_numbers.0.wind_up_conclusion_date"
+    },
+    {
+        "location": "case_numbers.0.instrument_date"
+    },
+    {
+        "location": "case_numbers.0.admin_order_date"
+    },
+    {
+        "location": "case_numbers.0.discharge_admin_order_date"
+    },
+    {
+        "location": "case_numbers.0.report_date"
+    },
+    {
+        "location": "case_numbers.0.completion_date"
+    },
+    {
+        "location": "case_numbers.0.admin_start_date"
+    },
+    {
+        "location": "case_numbers.0.admin_end_date"
+    },
+    {
+        "location": "case_numbers.0.appointment_date"
+    },
+    {
+        "location": "case_numbers.0.end_date"
+    }
+]

--- a/validation/schema_testing/insolvency/response_bodies/type_error_response_body
+++ b/validation/schema_testing/insolvency/response_bodies/type_error_response_body
@@ -1,101 +1,101 @@
 [
     {
-        "location": "case_numbers.0.case_number"
+        "location": "insolvency.0.case_numbers.0.case_number"
     },
     {
-        "location": "title"
+        "location": "insolvency.0.delta_at"
     },
     {
-        "location": "company_number"
+        "location": "insolvency.0.company_number"
     },
     {
-        "location": "case_numbers.0.case_type_id"
+        "location": "insolvency.0.case_numbers.0.case_type_id"
     },
     {
-        "location": "case_numbers.0.case_type"
+        "location": "insolvency.0.case_numbers.0.case_type"
     },
     {
-        "location": "case_numbers.0.mortgage_id"
+        "location": "insolvency.0.case_numbers.0.mortgage_id"
     },
     {
-        "location": "case_numbers.0.appointments.0.forename"
+        "location": "insolvency.0.case_numbers.0.appointments.0.forename"
     },
     {
-        "location": "case_numbers.0.appointments.0.middle_name"
+        "location": "insolvency.0.case_numbers.0.appointments.0.middle_name"
     },
     {
-        "location": "case_numbers.0.appointments.0.surname"
+        "location": "insolvency.0.case_numbers.0.appointments.0.surname"
     },
     {
-        "location": "case_numbers.0.appointments.0.appt_type"
+        "location": "insolvency.0.case_numbers.0.appointments.0.appt_type"
     },
     {
-        "location": "case_numbers.0.appointments.0.appt_date"
+        "location": "insolvency.0.case_numbers.0.appointments.0.appt_date"
     },
     {
-        "location": "case_numbers.0.appointments.0.ceased_to_act_appt"
+        "location": "insolvency.0.case_numbers.0.appointments.0.ceased_to_act_appt"
     },
     {
-        "location": "case_numbers.0.appointments.0.practitioner_address.address_line_1"
+        "location": "insolvency.0.case_numbers.0.appointments.0.practitioner_address.address_line_1"
     },
     {
-        "location": "case_numbers.0.appointments.0.practitioner_address.address_line_2"
+        "location": "insolvency.0.case_numbers.0.appointments.0.practitioner_address.address_line_2"
     },
     {
-        "location": "case_numbers.0.appointments.0.practitioner_address.locality"
+        "location": "insolvency.0.case_numbers.0.appointments.0.practitioner_address.locality"
     },
     {
-        "location": "case_numbers.0.appointments.0.practitioner_address.region"
+        "location": "insolvency.0.case_numbers.0.appointments.0.practitioner_address.region"
     },
     {
-        "location": "case_numbers.0.appointments.0.practitioner_address.country"
+        "location": "insolvency.0.case_numbers.0.appointments.0.practitioner_address.country"
     },
     {
-        "location": "case_numbers.0.appointments.0.practitioner_address.postal_code"
+        "location": "insolvency.0.case_numbers.0.appointments.0.practitioner_address.postal_code"
     },
     {
-        "location": "case_numbers.0.wind_up_date"
+        "location": "insolvency.0.case_numbers.0.wind_up_date"
     },
     {
-        "location": "case_numbers.0.dissolved_date"
+        "location": "insolvency.0.case_numbers.0.dissolved_date"
     },
     {
-        "location": "case_numbers.0.dissolved_due_date"
+        "location": "insolvency.0.case_numbers.0.dissolved_due_date"
     },
     {
-        "location": "case_numbers.0.sworn_date"
+        "location": "insolvency.0.case_numbers.0.sworn_date"
     },
     {
-        "location": "case_numbers.0.petition_date"
+        "location": "insolvency.0.case_numbers.0.petition_date"
     },
     {
-        "location": "case_numbers.0.wind_up_conclusion_date"
+        "location": "insolvency.0.case_numbers.0.wind_up_conclusion_date"
     },
     {
-        "location": "case_numbers.0.instrument_date"
+        "location": "insolvency.0.case_numbers.0.instrument_date"
     },
     {
-        "location": "case_numbers.0.admin_order_date"
+        "location": "insolvency.0.case_numbers.0.admin_order_date"
     },
     {
-        "location": "case_numbers.0.discharge_admin_order_date"
+        "location": "insolvency.0.case_numbers.0.discharge_admin_order_date"
     },
     {
-        "location": "case_numbers.0.report_date"
+        "location": "insolvency.0.case_numbers.0.report_date"
     },
     {
-        "location": "case_numbers.0.completion_date"
+        "location": "insolvency.0.case_numbers.0.completion_date"
     },
     {
-        "location": "case_numbers.0.admin_start_date"
+        "location": "insolvency.0.case_numbers.0.admin_start_date"
     },
     {
-        "location": "case_numbers.0.admin_end_date"
+        "location": "insolvency.0.case_numbers.0.admin_end_date"
     },
     {
-        "location": "case_numbers.0.appointment_date"
+        "location": "insolvency.0.case_numbers.0.appointment_date"
     },
     {
-        "location": "case_numbers.0.end_date"
+        "location": "insolvency.0.case_numbers.0.end_date"
     }
 ]


### PR DESCRIPTION
Update the Open API Spec to handle insolvency data so that the trigger can send this data to CHS

- Added the new delta to config
- Exposed the new delta endpoint
- Added unit tests for spec validation

Resolves:
DSND-344
DSND-345