### PR TITLE
Fix: Extended insolvency delta OpenApi spec validation

### DIFF
--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -44,6 +44,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CaseNumber'
+          minItems: 1
 
     CaseNumber:
       required:
@@ -90,34 +91,64 @@ components:
             $ref: '#/components/schemas/Appointment'
         wind_up_date:
           type: string
+          minLength: 8
+          maxLength: 8
         dissolved_date:
           type: string
+          minLength: 8
+          maxLength: 8
         dissolved_due_date:
           type: string
+          minLength: 8
+          maxLength: 8
         sworn_date:
           type: string
+          minLength: 8
+          maxLength: 8
         petition_date:
           type: string
+          minLength: 8
+          maxLength: 8
         wind_up_conclusion_date:
-          type: string 
+          type: string
+          minLength: 8
+          maxLength: 8
         instrument_date:
           type: string
+          minLength: 8
+          maxLength: 8
         admin_order_date:
           type: string
+          minLength: 8
+          maxLength: 8
         discharge_admin_order_date:
           type: string
+          minLength: 8
+          maxLength: 8
         report_date:
           type: string
+          minLength: 8
+          maxLength: 8
         completion_date:
           type: string
+          minLength: 8
+          maxLength: 8
         admin_start_date:
           type: string
+          minLength: 8
+          maxLength: 8
         admin_end_date:
           type: string
+          minLength: 8
+          maxLength: 8
         appointment_date:
           type: string
+          minLength: 8
+          maxLength: 8
         end_date:
           type: string
+          minLength: 8
+          maxLength: 8
 
     Appointment:
       type: object
@@ -144,8 +175,12 @@ components:
           - 8
         appt_date:
           type: string
+          minLength: 8
+          maxLength: 8
         ceased_to_act_appt:
           type: string
+          minLength: 8
+          maxLength: 8
         practitioner_address:
           $ref: '#/components/schemas/PractitionerAddress'
 

--- a/validation/schema_testing/insolvency/insolvencyDeltaSchema_test.go
+++ b/validation/schema_testing/insolvency/insolvencyDeltaSchema_test.go
@@ -11,15 +11,17 @@ import (
 )
 
 const (
-	requestBodiesLocation            = "./request_bodies/"
-	okRequestBodyLocation            = requestBodiesLocation + "ok_request_body"
-	typeErrorRequestBodyLocation     = requestBodiesLocation + "type_error_request_body"
-	requiredErrorRequestBodyLocation = requestBodiesLocation + "required_error_request_body"
+	requestBodiesLocation              = "./request_bodies/"
+	okRequestBodyLocation              = requestBodiesLocation + "ok_request_body"
+	typeErrorRequestBodyLocation       = requestBodiesLocation + "type_error_request_body"
+	requiredErrorRequestBodyLocation   = requestBodiesLocation + "required_error_request_body"
+	dateLengthErrorRequestBodyLocation = requestBodiesLocation + "date_length_error_request_body"
 
 	responseBodiesLocation                 = "./response_bodies/"
 	typeErrorResponseBodyLocation          = responseBodiesLocation + "type_error_response_body"
 	requiredErrorResponseBodyLocation      = responseBodiesLocation + "required_error_response_body"
 	noRequestBodyErrorResponseBodyLocation = responseBodiesLocation + "no_request_body_error_response_body"
+	dateLengthErrorResponseBodyLocation    = responseBodiesLocation + "date_length_error_response_body"
 
 	insolvencyEndpoint = "/delta/insolvency"
 	apiSpecLocation    = "../../../apispec/api-spec.yml"
@@ -79,7 +81,7 @@ func TestUnitInsolvencyDeltaSchemaTypeErrors(t *testing.T) {
 	})
 }
 
-// TestUnitInsolvencyDeltaSchemaRequiredErrors asserts that when an invalid request body is given with missing mandatory values.
+// TestUnitInsolvencyDeltaSchemaRequiredErrors asserts that when an invalid request body is given with missing mandatory values,
 // then an errors array is returned, stating that required values are missing.
 func TestUnitInsolvencyDeltaSchemaRequiredErrors(t *testing.T) {
 
@@ -99,6 +101,33 @@ func TestUnitInsolvencyDeltaSchemaRequiredErrors(t *testing.T) {
 			Convey("Then I am given an errors array response as validation errors have been found", func() {
 				mandatoryErrorsResponseBody := common.ReadRequestBody(requiredErrorResponseBodyLocation)
 				match := common.CompareActualToExpected(validationErrs, mandatoryErrorsResponseBody)
+
+				So(validationErrs, ShouldNotBeNil)
+				So(match, ShouldEqual, true)
+			})
+		})
+	})
+}
+
+// TestUnitInsolvencyDeltaDateLengthErrors asserts that when a request body is given with dates which are not of length 8
+// then an errors array is returned.
+// NOTE: there is no validation on the format of the dates in the spec, only properties asserted are type: string and [min|max]Length: 8
+func TestUnitInsolvencyDeltaDateLengthErrors(t *testing.T) {
+
+	Convey("Given I want to test the insolvency-delta API schema to assert mandatory validation is working correctly", t, func() {
+		dateErrorsRequestBody := common.ReadRequestBody(dateLengthErrorRequestBodyLocation)
+
+		r := httptest.NewRequest(methodPost, insolvencyEndpoint, bytes.NewBuffer(dateErrorsRequestBody))
+		r = common.SetHeaders(r)
+
+		Convey("When I call to validate the request body, providing an valid request with missing mandatory values", func() {
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
+
+			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, contextId)
+
+			Convey("Then I am given an errors array response as validation errors have been found", func() {
+				dateErrorsResponseBody := common.ReadRequestBody(dateLengthErrorResponseBodyLocation)
+				match := common.CompareActualToExpected(validationErrs, dateErrorsResponseBody)
 
 				So(validationErrs, ShouldNotBeNil)
 				So(match, ShouldEqual, true)

--- a/validation/schema_testing/insolvency/request_bodies/date_length_error_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/date_length_error_request_body
@@ -15,8 +15,8 @@
               "middle_name": "string",
               "surname": "string",
               "appt_type": 1,
-              "appt_date": "20110705",
-              "ceased_to_act_appt": "20211209",
+              "appt_date": "2021-12-13",
+              "ceased_to_act_appt": "2020210516",
               "practitioner_address": {
                 "address_line_1": "string",
                 "address_line_2": "string",
@@ -27,21 +27,21 @@
               }
             }
           ],
-          "wind_up_date": "20010705",
-          "dissolved_date": "20010705",
-          "dissolved_due_date": "20210823",
-          "sworn_date": "20210823",
-          "petition_date": "20210823",
-          "wind_up_conclusion_date": "20210823",
-          "instrument_date": "20210823",
-          "admin_order_date": "20210823",
-          "discharge_admin_order_date": "20210823",
-          "report_date": "20210823",
-          "completion_date": "20210823",
-          "admin_start_date": "20210823",
-          "admin_end_date": "20010705",
-          "appointment_date": "20010705",
-          "end_date": "20010705"
+          "wind_up_date": "string",
+          "dissolved_date": "stringTooLong",
+          "dissolved_due_date": "stringTooLong",
+          "sworn_date": "2020210516",
+          "petition_date": "2020210516",
+          "wind_up_conclusion_date": "2020210517",
+          "instrument_date": "2021-12-13",
+          "admin_order_date": "2021-12-13",
+          "discharge_admin_order_date": "stringTooLong",
+          "report_date": "string",
+          "completion_date": "2020210516",
+          "admin_start_date": "stringTooLong",
+          "admin_end_date": "2021-12-13",
+          "appointment_date": "string",
+          "end_date": "stringTooLong"
         }
       ]
     }

--- a/validation/schema_testing/insolvency/request_bodies/required_error_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/required_error_request_body
@@ -10,8 +10,8 @@
               "middle_name": "string",
               "surname": "string",
               "appt_type": 1,
-              "appt_date": "string",
-              "ceased_to_act_appt": "string",
+              "appt_date": "20210823",
+              "ceased_to_act_appt": "20010705",
               "practitioner_address": {
                 "address_line_1": "string",
                 "address_line_2": "string",
@@ -22,21 +22,21 @@
               }
             }
           ],
-          "wind_up_date": "string",
-          "dissolved_date": "string",
-          "dissolved_due_date": "string",
-          "sworn_date": "string",
-          "petition_date": "string",
-          "wind_up_conclusion_date": "string",
-          "instrument_date": "string",
-          "admin_order_date": "string",
-          "discharge_admin_order_date": "string",
-          "report_date": "string",
-          "completion_date": "string",
-          "admin_start_date": "string",
-          "admin_end_date": "string",
-          "appointment_date": "string",
-          "end_date": "string"
+          "wind_up_date": "20210823",
+          "dissolved_date": "20010705",
+          "dissolved_due_date": "20210823",
+          "sworn_date": "20010705",
+          "petition_date": "20010705",
+          "wind_up_conclusion_date": "20210823",
+          "instrument_date": "20210823",
+          "admin_order_date": "20210823",
+          "discharge_admin_order_date": "20210823",
+          "report_date": "20010705",
+          "completion_date": "20010705",
+          "admin_start_date": "20210823",
+          "admin_end_date": "20210823",
+          "appointment_date": "20210823",
+          "end_date": "20210823"
         }
       ]
     }

--- a/validation/schema_testing/insolvency/response_bodies/date_length_error_response_body
+++ b/validation/schema_testing/insolvency/response_bodies/date_length_error_response_body
@@ -1,0 +1,53 @@
+[
+    {
+        "location": "insolvency.0.case_numbers.0.appointments.0.appt_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.appointments.0.ceased_to_act_appt"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.wind_up_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.dissolved_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.dissolved_due_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.sworn_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.petition_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.wind_up_conclusion_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.instrument_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.admin_order_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.discharge_admin_order_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.report_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.completion_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.admin_start_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.admin_end_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.appointment_date"
+    },
+    {
+        "location": "insolvency.0.case_numbers.0.end_date"
+    }
+]


### PR DESCRIPTION
Following testing of DNSD-344 the following additional validation has been added to the insolvency delta:

- dates can only be 8 characters (unit tests added for this scenario)
  - Note: this does not include validation on the format of the date
-  the `case_number` array must now contain at least 1 item in addition to being a required field.


Addresses:
DSND-344