### PR TITLE
DSND-493 Increased the maxLength of notice_type fields to 50 as requested by CH

### DIFF
--- a/apispec/charges-delta-spec.yml
+++ b/apispec/charges-delta-spec.yml
@@ -45,7 +45,7 @@ components:
             $ref: '#/components/schemas/Person'
           minItems : 1
         notice_type:
-          maxLength: 15
+          maxLength: 50
           type: string
         trans_id:
           type: string
@@ -184,7 +184,7 @@ components:
       type: object
       properties:
         notice_type:
-          maxLength: 15
+          maxLength: 50
           type: string
         trans_id:
           type: string

--- a/validation/schema_testing/charges/request_bodies/date_length_error_request_body
+++ b/validation/schema_testing/charges/request_bodies/date_length_error_request_body
@@ -10,14 +10,14 @@
           "person": "string"
         }
       ],
-      "notice_type": "string123123123123",
+      "notice_type": "string123123123123242342342342342342342342342342342342342342342344234",
       "trans_id": "12345",
       "trans_desc": "string",
       "submission_type": "12345",
       "case": "0",
       "additional_notices": [
         {
-          "notice_type": "string123123123123",
+          "notice_type": "string123123123123242342342342342342342342342342342342342342342344234",
           "trans_id": "12345",
           "trans_desc": "string",
           "submission_type": "12345",


### PR DESCRIPTION
DSND-493 Increased the maxLength of notice_type fields to 50 as requested by CH