### PR TITLE
Update disqualification spec to match chips

### DIFF
--- a/apispec/disqualification-delta-spec.yml
+++ b/apispec/disqualification-delta-spec.yml
@@ -26,6 +26,8 @@ components:
             $ref: '#/components/schemas/DisqualificationOfficer'
         CreatedTime:
           type: string
+        delta_at:
+          type: string
 
     DisqualificationOfficer:
       properties:
@@ -80,19 +82,7 @@ components:
           items:
             $ref: '#/components/schemas/Exemption'
       required:
-        - officer_disq_id
-        - external_number
-        - officer_id
-        - officer_detail_id
-        - date_of_birth
-        - title
-        - forename
-        - middle_name
         - surname
-        - honours
-        - nationality
-        - registered_number
-        - registered_location
 
     Disqualification:
       type: object
@@ -138,6 +128,12 @@ components:
           items:
             type: string
             maxLength: 160
+      required:
+        - address
+        - disq_eff_date
+        - disq_end_date
+        - disq_type
+        - section_of_the_act
 
     DisqualificationAddress:
       type: object
@@ -186,3 +182,6 @@ components:
           items:
             type: string
             maxLength: 160
+      required:
+       - granted_on
+       - expires_on

--- a/validation/schema_testing/disqualifications/request_bodies/date_length_error_request_body
+++ b/validation/schema_testing/disqualifications/request_bodies/date_length_error_request_body
@@ -1,5 +1,6 @@
 {
   "CreatedTime": "20211008152823383176",
+  "delta_at" : "20211008152823383176",
   "disqualified_officer": [
     {
       "officer_disq_id": "string",

--- a/validation/schema_testing/disqualifications/request_bodies/ok_request_body
+++ b/validation/schema_testing/disqualifications/request_bodies/ok_request_body
@@ -1,5 +1,6 @@
 {
   "CreatedTime": "20211008152823383176",
+  "delta_at" : "20211008152823383176",
   "disqualified_officer": [
     {
       "officer_disq_id": "string",

--- a/validation/schema_testing/disqualifications/request_bodies/required_error_request_body
+++ b/validation/schema_testing/disqualifications/request_bodies/required_error_request_body
@@ -1,26 +1,26 @@
 {
   "CreatedTime": "20211008152823383176",
+  "delta_at" : "20211008152823383176",
   "disqualified_officer": [
     {
+      "officer_disq_id": "string",
+      "external_number": "string",
+      "officer_id": "string",
+      "officer_detail_id": "string",
+      "date_of_birth": "20110705",
+      "title": "string",
+      "forename": "string",
+      "middle_name": "string",
+      "honours": "string",
+      "nationality": "string",
+      "registered_number": "string",
+      "registered_location": "string",
       "corporate_ind": "string",
       "disqualifications": [
         {
-          "disq_eff_date": "20110705",
-          "disq_end_date": "20110705",
-          "disq_type": "string",
           "hearing_date": "20110705",
-          "section_of_the_act": "string",
           "court_ref": "string",
           "court_name": "string",
-          "address": {
-            "premise" : "string",
-            "address_line_1": "string",
-            "address_line_2": "string",
-            "locality": "string",
-            "region": "string",
-            "country": "string",
-            "postal_code": "string"
-          },
           "variation_court": "string",
           "variation_court_ref_no": "string",
           "var_instrument_start_date": "20110705",
@@ -32,8 +32,6 @@
       "exemptions": [
         {
             "court_name": "string",
-            "granted_on": "20110705",
-            "expires_on": "20110705",
             "purpose": "string",
             "company_names": [
               "string"

--- a/validation/schema_testing/disqualifications/request_bodies/type_error_request_body
+++ b/validation/schema_testing/disqualifications/request_bodies/type_error_request_body
@@ -1,5 +1,6 @@
 {
   "CreatedTime": 123,
+  "delta_at" : "20211008152823383176",
   "disqualified_officer": [
     {
       "officer_disq_id": 123,

--- a/validation/schema_testing/disqualifications/response_bodies/required_error_response_body
+++ b/validation/schema_testing/disqualifications/response_bodies/required_error_response_body
@@ -1,41 +1,26 @@
 [
     {
-        "location": "disqualified_officer.0.officer_disq_id"
-    },
-    {
-        "location": "disqualified_officer.0.external_number"
-    },
-    {
-        "location": "disqualified_officer.0.officer_id"
-    },
-    {
-        "location": "disqualified_officer.0.officer_detail_id"
-    },
-    {
-        "location": "disqualified_officer.0.date_of_birth"
-    },
-    {
-        "location": "disqualified_officer.0.title"
-    },
-    {
-        "location": "disqualified_officer.0.forename"
-    },
-    {
-        "location": "disqualified_officer.0.middle_name"
-    },
-    {
         "location": "disqualified_officer.0.surname"
     },
     {
-        "location": "disqualified_officer.0.honours"
+        "location": "disqualified_officer.0.disqualifications.0.address"
     },
     {
-        "location": "disqualified_officer.0.nationality"
+        "location": "disqualified_officer.0.disqualifications.0.disq_eff_date"
     },
     {
-        "location": "disqualified_officer.0.registered_number"
+        "location": "disqualified_officer.0.disqualifications.0.disq_end_date"
     },
     {
-        "location": "disqualified_officer.0.registered_location"
+        "location": "disqualified_officer.0.disqualifications.0.disq_type"
+    },
+    {
+        "location": "disqualified_officer.0.disqualifications.0.section_of_the_act"
+    },
+    {
+        "location": "disqualified_officer.0.exemptions.0.granted_on"
+    },
+    {
+        "location": "disqualified_officer.0.exemptions.0.expires_on"
     }
 ]


### PR DESCRIPTION
This PR adds the delta_at property and changes the required properties of the disqualification spec to match the mandatory fields in CHIPS.

**Resolves:**
- DSND-550