### PR TITLE
Add insolvency delta delete endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Service to send delta events from CHIPS on the correct kafka topic
 Environment Variables
 -----------------
 
-|  Variable                         |  Example                          |  Description                                        |  Required       | Default value |        
+|  Variable                         |  Example                          |  Description                                        |  Required       | Default value |
 | --------------------------------- | --------------------------------- | --------------------------------------------------  | --------------- | ------------- |
 | BIND_ADDR                         | 5010                              | Bind Address / application port                     | YES             |               |
 | KAFKA_BROKER_ADDR                 | chs-kafka:9092                    | Kafka broker address (can be comma separated)       | YES             |               |
@@ -13,7 +13,7 @@ Environment Variables
 | INSOLVENCY_DELTA_TOPIC            | insolvency-delta                  | Insolvency Delta Kafka topic to write messages to   | YES             |               |
 | CHARGES_DELTA_TOPIC               | charges-delta                     | Charges Delta Kafka topic to write messages to      | YES             |               |
 | DISQUALIFIED_OFFICERS_DELTA_TOPIC | disqualification-delta            | Disqualified Delta Kafka topic to write messages to | YES             |               |
-| OPEN_API_SPEC                     | ./apispec/apispec.yml             | OpenAPI schema location                             | YES             |               |
+| OPEN_API_SPEC                     | ./apispec/api-spec.yml            | OpenAPI schema location                             | YES             |               |
 | LOG_LEVEL                         | trace                             | The level at which the logger prints                | NO              | info          |
 
 ## Running Locally with Docker CHS

--- a/apispec/api-spec.yml
+++ b/apispec/api-spec.yml
@@ -11,6 +11,8 @@ paths:
     $ref: 'officer-delta-spec.yml'
   /delta/insolvency:
     $ref: 'insolvency-delta-spec.yml'
+  /delta/insolvency/delete:
+    $ref: 'insolvency-delete-delta-spec.yml'
   /delta/insolvency/validate:
     $ref: 'insolvency-delta-spec.yml'
   /delta/charges:

--- a/apispec/insolvency-delete-delta-spec.yml
+++ b/apispec/insolvency-delete-delta-spec.yml
@@ -1,0 +1,32 @@
+post:
+  summary: Accepts an incoming insolvency delta for a delete, transforms it into an avro schema and puts it onto a Kafka topic.
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/InsolvencyDeleteDelta'
+  responses:
+    '200':
+      description: Successfully added delete message onto Kafka topic.
+    '400':
+      description: Bad request body - validation errors.
+    '401':
+      description: Unauthorised - missing api key in header.
+    '500':
+      description: Internal server error has occured.
+
+components:
+  schemas:
+    InsolvencyDeleteDelta:
+      type: object
+      properties:
+        company_number:
+          type: string
+        action:
+          type: string
+          enum:
+            - DELETE
+      required:
+        - company_number
+        - action

--- a/handlers/deltaHandler.go
+++ b/handlers/deltaHandler.go
@@ -16,18 +16,20 @@ type DeltaHandler struct {
 	chv              validation.CHValidator
 	cfg              *config.Config
 	doValidationOnly bool
+	isDelete         bool
 	topic            string
 }
 
 // NewDeltaHandler returns an DeltaHandler.
 func NewDeltaHandler(kSvc services.KafkaService, h helpers.Helper, chv validation.CHValidator,
-	cfg *config.Config, doValidationOnly bool, topic string) *DeltaHandler {
+	cfg *config.Config, doValidationOnly bool, isDelete bool, topic string) *DeltaHandler {
 	return &DeltaHandler{
 		kSvc:             kSvc,
 		h:                h,
 		chv:              chv,
 		cfg:              cfg,
 		doValidationOnly: doValidationOnly,
+		isDelete:         isDelete,
 		topic:            topic,
 	}
 }
@@ -65,7 +67,7 @@ func (kp *DeltaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Send data string to Kafka service for publishing.
-		if err := kp.kSvc.SendMessage(kp.topic, data, contextId); err != nil {
+		if err := kp.kSvc.SendMessage(kp.topic, data, contextId, kp.isDelete); err != nil {
 			log.ErrorC(contextId, err, log.Data{config.TopicKey: kp.topic, config.MessageKey: "error sending the message to the given kafka topic"})
 			w.WriteHeader(http.StatusInternalServerError)
 

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -44,14 +44,15 @@ func Register(mainRouter *mux.Router, cfg *config.Config, kSvc services.KafkaSer
 	mainRouter.Use(log.Handler)
 
 	appRouter := mainRouter.PathPrefix("").Subrouter()
-	appRouter.HandleFunc("/delta/officers", NewDeltaHandler(kSvc, h, chv, cfg, false, cfg.OfficerDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("officer-delta")
-	appRouter.HandleFunc("/delta/officers/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, cfg.OfficerDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("officer-delta-validate")
-	appRouter.HandleFunc("/delta/insolvency", NewDeltaHandler(kSvc, h, chv, cfg, false, cfg.InsolvencyDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("insolvency-delta")
-	appRouter.HandleFunc("/delta/insolvency/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, cfg.InsolvencyDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("insolvency-delta-validate")
-	appRouter.HandleFunc("/delta/charges", NewDeltaHandler(kSvc, h, chv, cfg, false, cfg.ChargesDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("charges-delta")
-	appRouter.HandleFunc("/delta/charges/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, cfg.ChargesDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("charges-delta-validate")
-	appRouter.HandleFunc("/delta/disqualification", NewDeltaHandler(kSvc, h, chv, cfg, false, cfg.DisqualifiedDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("disqualified-officer-delta")
-	appRouter.HandleFunc("/delta/disqualification/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, cfg.DisqualifiedDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("disqualified-officer-delta-validate")
+	appRouter.HandleFunc("/delta/officers", NewDeltaHandler(kSvc, h, chv, cfg, false, false, cfg.OfficerDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("officer-delta")
+	appRouter.HandleFunc("/delta/officers/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, false, cfg.OfficerDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("officer-delta-validate")
+	appRouter.HandleFunc("/delta/insolvency", NewDeltaHandler(kSvc, h, chv, cfg, false, false, cfg.InsolvencyDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("insolvency-delta")
+	appRouter.HandleFunc("/delta/insolvency/delete", NewDeltaHandler(kSvc, h, chv, cfg, false, true, cfg.InsolvencyDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("insolvency-delta")
+	appRouter.HandleFunc("/delta/insolvency/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, false, cfg.InsolvencyDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("insolvency-delta-validate")
+	appRouter.HandleFunc("/delta/charges", NewDeltaHandler(kSvc, h, chv, cfg, false, false, cfg.ChargesDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("charges-delta")
+	appRouter.HandleFunc("/delta/charges/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, false, cfg.ChargesDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("charges-delta-validate")
+	appRouter.HandleFunc("/delta/disqualification", NewDeltaHandler(kSvc, h, chv, cfg, false, false, cfg.DisqualifiedDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("disqualified-officer-delta")
+	appRouter.HandleFunc("/delta/disqualification/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, false, cfg.DisqualifiedDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("disqualified-officer-delta-validate")
 	appRouter.Use(userAuthInterceptor.UserAuthenticationIntercept)
 	return nil
 }

--- a/models/chsDelta.go
+++ b/models/chsDelta.go
@@ -5,4 +5,5 @@ type ChsDelta struct {
 	Data      string `avro:"data"`
 	Attempt   int32  `avro:"attempt"`
 	ContextId string `avro:"context_id"`
+	IsDelete  bool   `avro:"is_delete"`
 }

--- a/services/kafkaService.go
+++ b/services/kafkaService.go
@@ -26,7 +26,7 @@ var (
 // KafkaService defines all Methods needed to successfully send a message onto a Kafka topic.
 type KafkaService interface {
 	Init(cfg *config.Config) error
-	SendMessage(topic, data, contextId string) error
+	SendMessage(topic, data, contextId string, isDelete bool) error
 }
 
 // KafkaServiceImpl is a concrete implementation of the KafkaService interface.
@@ -86,7 +86,7 @@ func initProducer(cfg *config.Config) (*producer.Producer, error) {
 }
 
 // SendMessage publishes a given data string retrieved from a REST request onto a chosen Kafka topic.
-func (kSvc *KafkaServiceImpl) SendMessage(topic, data, contextId string) error {
+func (kSvc *KafkaServiceImpl) SendMessage(topic, data, contextId string, isDelete bool) error {
 
 	// Retrieve our chs-delta avro schema using the chs go avro package.
 	chsDeltaAvro := &avro.Schema{
@@ -97,6 +97,7 @@ func (kSvc *KafkaServiceImpl) SendMessage(topic, data, contextId string) error {
 	deltaData := models.ChsDelta{
 		ContextId: contextId,
 		Data:      data,
+		IsDelete:  isDelete,
 	}
 
 	// Marshall the chs-delta previously created into the avro schema and convert it to a []byte for sending.
@@ -118,6 +119,8 @@ func (kSvc *KafkaServiceImpl) SendMessage(topic, data, contextId string) error {
 	}
 
 	log.InfoC(contextId, "Sent message", log.Data{config.TopicKey: producerMessage.Topic, config.PartitionKey: partition, config.OffsetKey: offset})
+	log.TraceC(contextId, "Message data", log.Data{config.MessageKey: deltaData})
+
 	return nil
 }
 

--- a/services/kafkaService_test.go
+++ b/services/kafkaService_test.go
@@ -117,7 +117,7 @@ func TestUnitSendMessageSuccessfully(t *testing.T) {
 				return int32(0), int64(0), nil
 			}
 
-			err := k.SendMessage(Topic, Data, ContextId)
+			err := k.SendMessage(Topic, Data, ContextId, false)
 
 			Convey("Then there are no errors", func() {
 				So(err, ShouldBeNil)
@@ -134,7 +134,7 @@ func TestUnitSendMessageFailsSchemaMarshalling(t *testing.T) {
 
 		Convey("When I call to send a message via the producer", func() {
 
-			err := k.SendMessage(Topic, Data, ContextId)
+			err := k.SendMessage(Topic, Data, ContextId, false)
 
 			Convey("Then there are errors returned", func() {
 				So(err, ShouldNotBeNil)
@@ -154,7 +154,7 @@ func TestUnitSendMessageFailsWithError(t *testing.T) {
 				return int32(0), int64(0), errors.New("error sending to kafka producer")
 			}
 
-			err := k.SendMessage(Topic, Data, ContextId)
+			err := k.SendMessage(Topic, Data, ContextId, false)
 
 			Convey("Then there are errors returned", func() {
 				So(err, ShouldNotBeNil)

--- a/services/mocks/kafkaService_mock.go
+++ b/services/mocks/kafkaService_mock.go
@@ -49,7 +49,7 @@ func (mr *MockKafkaServiceMockRecorder) Init(cfg interface{}) *gomock.Call {
 }
 
 // SendMessage mocks base method.
-func (m *MockKafkaService) SendMessage(topic, data, contextId string) error {
+func (m *MockKafkaService) SendMessage(topic, data, contextId string, isDelete bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendMessage", topic, data, contextId)
 	ret0, _ := ret[0].(error)
@@ -57,7 +57,7 @@ func (m *MockKafkaService) SendMessage(topic, data, contextId string) error {
 }
 
 // SendMessage indicates an expected call of SendMessage.
-func (mr *MockKafkaServiceMockRecorder) SendMessage(topic, data, contextId interface{}) *gomock.Call {
+func (mr *MockKafkaServiceMockRecorder) SendMessage(topic, data, contextId interface{}, isDelete bool) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMessage", reflect.TypeOf((*MockKafkaService)(nil).SendMessage), topic, data, contextId)
 }

--- a/validation/schema_testing/insolvency/insolvencyDeltaSchema_test.go
+++ b/validation/schema_testing/insolvency/insolvencyDeltaSchema_test.go
@@ -13,6 +13,7 @@ import (
 const (
 	requestBodiesLocation              = "./request_bodies/"
 	okRequestBodyLocation              = requestBodiesLocation + "ok_request_body"
+	deleteRequestBodyLocation          = requestBodiesLocation + "delete_request_body"
 	typeErrorRequestBodyLocation       = requestBodiesLocation + "type_error_request_body"
 	requiredErrorRequestBodyLocation   = requestBodiesLocation + "required_error_request_body"
 	dateLengthErrorRequestBodyLocation = requestBodiesLocation + "date_length_error_request_body"
@@ -23,10 +24,11 @@ const (
 	noRequestBodyErrorResponseBodyLocation = responseBodiesLocation + "no_request_body_error_response_body"
 	dateLengthErrorResponseBodyLocation    = responseBodiesLocation + "date_length_error_response_body"
 
-	insolvencyEndpoint = "/delta/insolvency"
-	apiSpecLocation    = "../../../apispec/api-spec.yml"
-	contextId          = "contextId"
-	methodPost         = "POST"
+	insolvencyEndpoint       = "/delta/insolvency"
+	insolvencyDeleteEndpoint = "/delta/insolvency/delete"
+	apiSpecLocation          = "../../../apispec/api-spec.yml"
+	contextId                = "contextId"
+	methodPost               = "POST"
 )
 
 // TestUnitInsolvencyDeltaSchemaNoErrors asserts that when a valid request body is given which matches the schema, then no
@@ -38,6 +40,30 @@ func TestUnitInsolvencyDeltaSchemaNoErrors(t *testing.T) {
 		okRequestBody := common.ReadRequestBody(okRequestBodyLocation)
 
 		r := httptest.NewRequest(methodPost, insolvencyEndpoint, bytes.NewBuffer(okRequestBody))
+		r = common.SetHeaders(r)
+
+		Convey("When I call to validate the request body, providing a valid request", func() {
+
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
+
+			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, contextId)
+
+			Convey("Then I am given a nil response as no validation errors are returned", func() {
+				So(validationErrs, ShouldBeNil)
+			})
+		})
+	})
+}
+
+// TestUnitInsolvencyDeleteDeltaSchemaNoErrors asserts that when a valid request body is given which matches the schema, then no
+// errors are returned.
+func TestUnitInsolvencyDeleteDeltaSchemaNoErrors(t *testing.T) {
+
+	Convey("Given I want to test the insolvency-delete-delta API schema", t, func() {
+
+		deleteRequestBody := common.ReadRequestBody(deleteRequestBodyLocation)
+
+		r := httptest.NewRequest(methodPost, insolvencyDeleteEndpoint, bytes.NewBuffer(deleteRequestBody))
 		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing a valid request", func() {

--- a/validation/schema_testing/insolvency/request_bodies/delete_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/delete_request_body
@@ -1,0 +1,4 @@
+{
+    "company_number": "9999",
+    "action": "DELETE"
+}


### PR DESCRIPTION
This PR is to add a delete endpoint for the insolvency delta so that the delta consumer will be able to identify deletes and deserialize the content within the Kafka message, this includes adding an isDelete param to the endpoint that is then transferred to the CHS Delta AVRO object.

**Resolves**
- DSND-697