### PR TITLE
Add charges delta delete endpoint

### DIFF
--- a/apispec/api-spec.yml
+++ b/apispec/api-spec.yml
@@ -17,6 +17,8 @@ paths:
     $ref: 'insolvency-delta-spec.yml'
   /delta/charges:
     $ref: 'charges-delta-spec.yml'
+  /delta/charges/delete:
+    $ref: 'charges-delete-delta-spec.yml'
   /delta/charges/validate:
     $ref: 'charges-delta-spec.yml'
   /delta/disqualification:

--- a/apispec/charges-delete-delta-spec.yml
+++ b/apispec/charges-delete-delta-spec.yml
@@ -1,0 +1,32 @@
+post:
+  summary: Accepts an incoming charges delta for a delete, transforms it into an avro schema and puts it onto a Kafka topic.
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ChargesDeleteDelta'
+  responses:
+    '200':
+      description: Successfully added delete message onto Kafka topic.
+    '400':
+      description: Bad request body - validation errors.
+    '401':
+      description: Unauthorised - missing api key in header.
+    '500':
+      description: Internal server error has occured.
+
+components:
+  schemas:
+    ChargesDeleteDelta:
+      type: object
+      properties:
+        charges_id:
+          type: string
+        action:
+          type: string
+          enum:
+            - DELETE
+      required:
+        - charges_id
+        - action

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -50,6 +50,7 @@ func Register(mainRouter *mux.Router, cfg *config.Config, kSvc services.KafkaSer
 	appRouter.HandleFunc("/delta/insolvency/delete", NewDeltaHandler(kSvc, h, chv, cfg, false, true, cfg.InsolvencyDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("insolvency-delta")
 	appRouter.HandleFunc("/delta/insolvency/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, false, cfg.InsolvencyDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("insolvency-delta-validate")
 	appRouter.HandleFunc("/delta/charges", NewDeltaHandler(kSvc, h, chv, cfg, false, false, cfg.ChargesDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("charges-delta")
+	appRouter.HandleFunc("/delta/charges/delete", NewDeltaHandler(kSvc, h, chv, cfg, false, true, cfg.ChargesDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("charges-delta")
 	appRouter.HandleFunc("/delta/charges/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, false, cfg.ChargesDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("charges-delta-validate")
 	appRouter.HandleFunc("/delta/disqualification", NewDeltaHandler(kSvc, h, chv, cfg, false, false, cfg.DisqualifiedDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("disqualified-officer-delta")
 	appRouter.HandleFunc("/delta/disqualification/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, false, cfg.DisqualifiedDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("disqualified-officer-delta-validate")

--- a/services/kafkaService.go
+++ b/services/kafkaService.go
@@ -119,7 +119,7 @@ func (kSvc *KafkaServiceImpl) SendMessage(topic, data, contextId string, isDelet
 	}
 
 	log.InfoC(contextId, "Sent message", log.Data{config.TopicKey: producerMessage.Topic, config.PartitionKey: partition, config.OffsetKey: offset})
-	log.TraceC(contextId, "Message data", log.Data{config.MessageKey: deltaData})
+	log.InfoC(contextId, "Message data", log.Data{config.MessageKey: deltaData})
 
 	return nil
 }

--- a/services/kafkaService.go
+++ b/services/kafkaService.go
@@ -119,7 +119,7 @@ func (kSvc *KafkaServiceImpl) SendMessage(topic, data, contextId string, isDelet
 	}
 
 	log.InfoC(contextId, "Sent message", log.Data{config.TopicKey: producerMessage.Topic, config.PartitionKey: partition, config.OffsetKey: offset})
-	log.InfoC(contextId, "Message data", log.Data{config.MessageKey: deltaData})
+	log.TraceC(contextId, "Message data", log.Data{config.MessageKey: deltaData})
 
 	return nil
 }

--- a/validation/schema_testing/charges/chargesDeltaSchema_test.go
+++ b/validation/schema_testing/charges/chargesDeltaSchema_test.go
@@ -13,6 +13,7 @@ import (
 const (
 	requestBodiesLocation              = "./request_bodies/"
 	okRequestBodyLocation              = requestBodiesLocation + "ok_request_body"
+	deleteRequestBodyLocation          = requestBodiesLocation + "delete_request_body"
 	typeErrorRequestBodyLocation       = requestBodiesLocation + "type_error_request_body"
 	requiredErrorRequestBodyLocation   = requestBodiesLocation + "required_error_request_body"
 	dateLengthErrorRequestBodyLocation = requestBodiesLocation + "date_length_error_request_body"
@@ -25,10 +26,11 @@ const (
 	dateLengthErrorResponseBodyLocation    = responseBodiesLocation + "date_length_error_response_body"
 	regexErrorResponseBodyLocation         = responseBodiesLocation + "regex_error_response_body"
 
-	chargesEndpoint = "/delta/charges"
-	apiSpecLocation = "../../../apispec/api-spec.yml"
-	contextId       = "contextId"
-	methodPost      = "POST"
+	chargesEndpoint       = "/delta/charges"
+	chargesDeleteEndpoint = "/delta/charges/delete"
+	apiSpecLocation       = "../../../apispec/api-spec.yml"
+	contextId             = "contextId"
+	methodPost            = "POST"
 )
 
 // TestUnitChargesDeltaSchemaNoErrors asserts that when a valid request body is given which matches the schema, then no
@@ -40,6 +42,30 @@ func TestUnitChargesDeltaSchemaNoErrors(t *testing.T) {
 		okRequestBody := common.ReadRequestBody(okRequestBodyLocation)
 
 		r := httptest.NewRequest(methodPost, chargesEndpoint, bytes.NewBuffer(okRequestBody))
+		r = common.SetHeaders(r)
+
+		Convey("When I call to validate the request body, providing a valid request", func() {
+
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
+
+			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, contextId)
+
+			Convey("Then I am given a nil response as no validation errors are returned", func() {
+				So(validationErrs, ShouldBeNil)
+			})
+		})
+	})
+}
+
+// TestUnitChargesDeleteDeltaSchemaNoErrors asserts that when a valid request body is given which matches the schema, then no
+// errors are returned.
+func TestUnitChargesDeleteDeltaSchemaNoErrors(t *testing.T) {
+
+	Convey("Given I want to test the charges-delete-delta API schema", t, func() {
+
+		deleteRequestBody := common.ReadRequestBody(deleteRequestBodyLocation)
+
+		r := httptest.NewRequest(methodPost, chargesDeleteEndpoint, bytes.NewBuffer(deleteRequestBody))
 		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing a valid request", func() {

--- a/validation/schema_testing/charges/request_bodies/delete_request_body
+++ b/validation/schema_testing/charges/request_bodies/delete_request_body
@@ -1,0 +1,4 @@
+{
+    "charges_id": "99999",
+    "action": "DELETE"
+}


### PR DESCRIPTION
This PR is to add a delete endpoint for the charges delta so that the delta consumer will be able to identify deletes and deserialize the content within the Kafka message.

**Resolves**

- DSND-698