### PR TITLE
DSND-955: Staging-E2E-insolvency

### DIFF
--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -87,6 +87,7 @@ components:
           type: string
         appointments:
           type: array
+          default: []
           items:
             $ref: '#/components/schemas/Appointment'
         wind_up_date:


### PR DESCRIPTION
DSND-955: Staging-E2E-insolvency - practitioners field non existent when no appointments in the delta