### PR TITLE
Add disqualification delta delete endpoint

### DIFF
--- a/apispec/api-spec.yml
+++ b/apispec/api-spec.yml
@@ -23,6 +23,8 @@ paths:
     $ref: 'charges-delta-spec.yml'
   /delta/disqualification:
     $ref: 'disqualification-delta-spec.yml'
+  /delta/disqualification/delete:
+    $ref: 'disqualification-delete-delta-spec.yml'
   /delta/disqualification/validate:
     $ref: 'disqualification-delta-spec.yml'
 

--- a/apispec/disqualification-delete-delta-spec.yml
+++ b/apispec/disqualification-delete-delta-spec.yml
@@ -1,0 +1,32 @@
+post:
+  summary: Accepts an incoming officer disqualification delta for a delete, transforms it into an avro schema and puts it onto a Kafka topic.
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/DisqualificationDeleteDelta'
+  responses:
+    '200':
+      description: Successfully added delete message onto Kafka topic.
+    '400':
+      description: Bad request body - validation errors.
+    '401':
+      description: Unauthorised - missing api key in header.
+    '500':
+      description: Internal server error has occurred.
+
+components:
+  schemas:
+    DisqualificationDeleteDelta:
+      type: object
+      properties:
+        officer_id:
+          type: string
+        action:
+          type: string
+          enum:
+            - DELETE
+      required:
+        - officer_id
+        - action

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -53,6 +53,7 @@ func Register(mainRouter *mux.Router, cfg *config.Config, kSvc services.KafkaSer
 	appRouter.HandleFunc("/delta/charges/delete", NewDeltaHandler(kSvc, h, chv, cfg, false, true, cfg.ChargesDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("charges-delta")
 	appRouter.HandleFunc("/delta/charges/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, false, cfg.ChargesDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("charges-delta-validate")
 	appRouter.HandleFunc("/delta/disqualification", NewDeltaHandler(kSvc, h, chv, cfg, false, false, cfg.DisqualifiedDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("disqualified-officer-delta")
+	appRouter.HandleFunc("/delta/disqualification/delete", NewDeltaHandler(kSvc, h, chv, cfg, false, true, cfg.DisqualifiedDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("disqualified-officer-delta")
 	appRouter.HandleFunc("/delta/disqualification/validate", NewDeltaHandler(kSvc, h, chv, cfg, true, false, cfg.DisqualifiedDeltaTopic).ServeHTTP).Methods(http.MethodPost).Name("disqualified-officer-delta-validate")
 	appRouter.Use(userAuthInterceptor.UserAuthenticationIntercept)
 	return nil

--- a/validation/schema_testing/disqualifications/disqualificationsDeltaSchema_test.go
+++ b/validation/schema_testing/disqualifications/disqualificationsDeltaSchema_test.go
@@ -13,6 +13,7 @@ import (
 const (
 	requestBodiesLocation              = "./request_bodies/"
 	okRequestBodyLocation              = requestBodiesLocation + "ok_request_body"
+	deleteRequestBodyLocation          = requestBodiesLocation + "delete_request_body"
 	typeErrorRequestBodyLocation       = requestBodiesLocation + "type_error_request_body"
 	requiredErrorRequestBodyLocation   = requestBodiesLocation + "required_error_request_body"
 	dateLengthErrorRequestBodyLocation = requestBodiesLocation + "date_length_error_request_body"
@@ -23,10 +24,11 @@ const (
 	noRequestBodyErrorResponseBodyLocation = responseBodiesLocation + "no_request_body_error_response_body"
 	dateLengthErrorResponseBodyLocation    = responseBodiesLocation + "date_length_error_response_body"
 
-	disqualificationEndpoint = "/delta/disqualification"
-	apiSpecLocation          = "../../../apispec/api-spec.yml"
-	contextId                = "contextId"
-	methodPost               = "POST"
+	disqualificationEndpoint       = "/delta/disqualification"
+	disqualificationDeleteEndpoint = "/delta/disqualification/delete"
+	apiSpecLocation                = "../../../apispec/api-spec.yml"
+	contextId                      = "contextId"
+	methodPost                     = "POST"
 )
 
 // TestUnitDisqualificationDeltaSchemaNoErrors asserts that when a valid request body is given which matches the schema, then no
@@ -38,6 +40,30 @@ func TestUnitDisqualificationDeltaSchemaNoErrors(t *testing.T) {
 		okRequestBody := common.ReadRequestBody(okRequestBodyLocation)
 
 		r := httptest.NewRequest(methodPost, disqualificationEndpoint, bytes.NewBuffer(okRequestBody))
+		r = common.SetHeaders(r)
+
+		Convey("When I call to validate the request body, providing a valid request", func() {
+
+			chv, _ := validation.NewCHValidator(apiSpecLocation)
+
+			validationErrs, _ := chv.ValidateRequestAgainstOpenApiSpec(r, contextId)
+
+			Convey("Then I am given a nil response as no validation errors are returned", func() {
+				So(validationErrs, ShouldBeNil)
+			})
+		})
+	})
+}
+
+// TestUnitDisqualificationDeleteDeltaSchemaNoErrors asserts that when a valid request body is given which matches the schema, then no
+// errors are returned.
+func TestUnitDisqualificationDeleteDeltaSchemaNoErrors(t *testing.T) {
+
+	Convey("Given I want to test the disqualification-delete-delta API schema", t, func() {
+
+		deleteRequestBody := common.ReadRequestBody(deleteRequestBodyLocation)
+
+		r := httptest.NewRequest(methodPost, disqualificationDeleteEndpoint, bytes.NewBuffer(deleteRequestBody))
 		r = common.SetHeaders(r)
 
 		Convey("When I call to validate the request body, providing a valid request", func() {

--- a/validation/schema_testing/disqualifications/request_bodies/delete_request_body
+++ b/validation/schema_testing/disqualifications/request_bodies/delete_request_body
@@ -1,0 +1,4 @@
+{
+    "officer_id": "1234567",
+    "action": "DELETE"
+}


### PR DESCRIPTION
This PR is to add a delete endpoint for the disqualification delta so that the delta consumer will be able to identify deletes and deserialize the content within the Kafka message.

**Resolves**
- DSND-674