### PR TITLE
Add officer id validation

### DIFF
--- a/apispec/disqualification-delete-delta-spec.yml
+++ b/apispec/disqualification-delete-delta-spec.yml
@@ -23,6 +23,8 @@ components:
       properties:
         officer_id:
           type: string
+          minLength: 1
+          maxLength: 10
         action:
           type: string
           enum:


### PR DESCRIPTION
This PR is to add validation to the officer id so that it cannot be blank when sending a delete request.

**DSND-674**