### PR TITLE
Make practitioner forename and surname mandatory

### DIFF
--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -155,12 +155,14 @@ components:
       properties:
         forename:
           type: string
+          minLength: 1
           maxLength: 50
         middle_name:
           type: string
           maxLength: 50
         surname:
           type: string
+          minLength: 1
           maxLength: 160
         appt_type:
           type: string


### PR DESCRIPTION
This pr adds mandatory validation for the practitioner forename and surname on insolvency cases sent to the delta api.

**Resolves:**
- DSND-925