### PR TITLE
Make forename/surname required insolvency practitioner fields

### DIFF
--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -151,6 +151,9 @@ components:
           maxLength: 8
 
     Appointment:
+      required: 
+      - forename
+      - surname
       type: object
       properties:
         forename:


### PR DESCRIPTION
This pr adds required validation to forename and surname for the insolvency practitioner appointment. This is to fix an issue where omitting the fields would allow the submission through.

**Required for:**
- DSND-925 