### PR TITLE
remove minimum forename length check appointments field

### DIFF
--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -158,7 +158,6 @@ components:
       properties:
         forename:
           type: string
-          minLength: 1
           maxLength: 50
         middle_name:
           type: string


### PR DESCRIPTION
This PR removes the minimum length of the forename field to allow corporate bodies through the chs-delta-api.

**Resolves**
DSND-1200