### PR TITLE
Added person number into Officer object

### DIFF
--- a/apispec/officer-delta-spec.yml
+++ b/apispec/officer-delta-spec.yml
@@ -97,6 +97,8 @@ components:
         usual_residential_country:
           type: string
           maxLength: 160
+        person_number:
+          type: string
         previous_name_array:
           type: array
           items:


### PR DESCRIPTION
This pr adds person_number field of type string into the Officer object for the officer-delta-spec.yml. This is required so the delta api will include the person_number in the officer-delta kafka message when the chs-delta-api officer endpoint is called with the person_number field present.

Required for:

- DSND-1400

[DSND-1400]: https://companieshouse.atlassian.net/browse/DSND-1400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ