### PR TITLE
add address enums in accordance with psc-delta spec

### DIFF
--- a/apispec/psc-delta-spec.yml
+++ b/apispec/psc-delta-spec.yml
@@ -137,6 +137,16 @@ components:
           type: string
         country_registered:
           type: string
+        service_address_same_as_registered_office:
+          type: string
+          enum:
+            - 'Y'
+            - 'N'
+        residential_address_same_as_service_address:
+          type: string
+          enum:
+            - 'Y'
+            - 'N'
       required:
         - company_number
         - internal_id


### PR DESCRIPTION
Added "residential_address_same_as_service_address" and "service_address_same_as_registered_office" to match with the psc spec in private.api.ch.gov.uk-specifications.