### PR TITLE
DSND-1960: Add company name and status to officer delta

### DIFF
--- a/apispec/officer-delta-spec.yml
+++ b/apispec/officer-delta-spec.yml
@@ -38,6 +38,12 @@ components:
       properties:
         company_number:
           type: string
+        company_name:
+          type: string
+          maxLength: 160
+        status:
+          type: string
+          maxLength: 160
         changed_at:
           type: string
         kind:
@@ -116,6 +122,7 @@ components:
         - officer_id
         - officer_detail_id
         - secure_director
+        - status
 
     Previous_name_array:
       type: object

--- a/validation/schema_testing/officers/request_bodies/enum_error_request_body
+++ b/validation/schema_testing/officers/request_bodies/enum_error_request_body
@@ -2,6 +2,8 @@
   "officers": [
     {
       "company_number": "string",
+      "company_name": "string",
+      "status": "string",
       "changed_at": "string",
       "kind": "string",
       "internal_id": "string",

--- a/validation/schema_testing/officers/request_bodies/max_properties_request_body
+++ b/validation/schema_testing/officers/request_bodies/max_properties_request_body
@@ -2,6 +2,8 @@
   "officers": [
     {
       "company_number": "string",
+      "company_name": "string",
+      "status": "string",
       "changed_at": "string",
       "kind": "string",
       "internal_id": "string",

--- a/validation/schema_testing/officers/request_bodies/ok_request_body
+++ b/validation/schema_testing/officers/request_bodies/ok_request_body
@@ -2,6 +2,8 @@
   "officers": [
     {
       "company_number": "string",
+      "company_name": "string",
+      "status": "string",
       "changed_at": "string",
       "kind": "string",
       "internal_id": "string",

--- a/validation/schema_testing/officers/request_bodies/type_error_request_body
+++ b/validation/schema_testing/officers/request_bodies/type_error_request_body
@@ -2,6 +2,8 @@
   "officers": [
     {
       "company_number": 123,
+      "company_name": 123,
+      "status": 123,
       "changed_at": 123,
       "kind": 123,
       "internal_id": 123,

--- a/validation/schema_testing/officers/response_bodies/required_error_response_body
+++ b/validation/schema_testing/officers/response_bodies/required_error_response_body
@@ -1,5 +1,14 @@
 [
     {
+        "error": "property 'status' is missing",
+        "error_values": {
+            "status": ""
+        },
+        "location": "officers.0.status",
+        "location_type": "json-path",
+        "type": "ch:validation"
+    },
+    {
         "error": "property 'corporate_ind' is missing",
         "error_values": {
             "corporate_ind": ""

--- a/validation/schema_testing/officers/response_bodies/type_error_response_body
+++ b/validation/schema_testing/officers/response_bodies/type_error_response_body
@@ -11,6 +11,24 @@
     {
         "error": "Field must be set to string or not be present",
         "error_values": {
+            "kind": "number, integer"
+        },
+        "location": "officers.0.company_name",
+        "location_type": "json-path",
+        "type": "ch:validation"
+    },
+    {
+        "error": "Field must be set to string or not be present",
+        "error_values": {
+            "kind": "number, integer"
+        },
+        "location": "officers.0.status",
+        "location_type": "json-path",
+        "type": "ch:validation"
+    },
+    {
+        "error": "Field must be set to string or not be present",
+        "error_values": {
             "internal_id": "number, integer"
         },
         "location": "officers.0.internal_id",


### PR DESCRIPTION
* Status is a required field on the officer delta as every officer must be appointed to a company.

[DSND-1960](https://companieshouse.atlassian.net/browse/DSND-1960)

[DSND-1960]: https://companieshouse.atlassian.net/browse/DSND-1960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ