### PR TITLE
DSND-2728: Add status field to insolvency delta spec

### DIFF
--- a/apispec/insolvency-delta-spec.yml
+++ b/apispec/insolvency-delta-spec.yml
@@ -34,6 +34,7 @@ components:
       - delta_at
       - company_number
       - case_numbers
+      - status
       type: object
       properties:
         delta_at:
@@ -46,6 +47,8 @@ components:
           items:
             $ref: '#/components/schemas/CaseNumber'
           minItems: 1
+        status:
+          type: string
 
     CaseNumber:
       required:

--- a/validation/schema_testing/insolvency/request_bodies/date_length_error_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/date_length_error_request_body
@@ -3,6 +3,7 @@
     {
       "delta_at": "20211008152823383176",
       "company_number": "string",
+      "status": "A",
       "case_numbers": [
         {
           "case_number": "0",

--- a/validation/schema_testing/insolvency/request_bodies/ok_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/ok_request_body
@@ -3,6 +3,7 @@
     {
       "delta_at": "20211008152823383176",
       "company_number": "string",
+      "status": "A",
       "case_numbers": [
         {
           "case_number": "0",

--- a/validation/schema_testing/insolvency/request_bodies/required_error_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/required_error_request_body
@@ -1,6 +1,7 @@
 {
   "insolvency": [
     {
+      "status": "A",
       "case_numbers": [
         {
           "mortgage_id": "0",

--- a/validation/schema_testing/insolvency/request_bodies/type_error_request_body
+++ b/validation/schema_testing/insolvency/request_bodies/type_error_request_body
@@ -3,6 +3,7 @@
     {
       "delta_at": 123,
       "company_number": 123,
+      "status": "A",
       "case_numbers": [
         {
           "case_number": 0,


### PR DESCRIPTION
This PR adds `status` as a  required field to the insolvency delta spec.

[DSND-2728](https://companieshouse.atlassian.net/browse/DSND-2728)

[DSND-2728]: https://companieshouse.atlassian.net/browse/DSND-2728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ