### PR TITLE
DSND-3109: Make delta_at required for delete deltas

### DIFF
--- a/apispec/charges-delete-delta-spec.yml
+++ b/apispec/charges-delete-delta-spec.yml
@@ -32,3 +32,4 @@ components:
       required:
         - charges_id
         - action
+        - delta_at

--- a/apispec/company-delete-delta-spec.yml
+++ b/apispec/company-delete-delta-spec.yml
@@ -32,3 +32,4 @@ components:
       required:
         - company_number
         - action
+        - delta_at

--- a/apispec/disqualification-delete-delta-spec.yml
+++ b/apispec/disqualification-delete-delta-spec.yml
@@ -34,3 +34,4 @@ components:
       required:
         - officer_id
         - action
+        - delta_at

--- a/apispec/filing-history-delete-delta-spec.yml
+++ b/apispec/filing-history-delete-delta-spec.yml
@@ -34,3 +34,4 @@ components:
       required:
         - entity_id
         - action
+        - delta_at

--- a/apispec/insolvency-delete-delta-spec.yml
+++ b/apispec/insolvency-delete-delta-spec.yml
@@ -34,3 +34,4 @@ components:
       required:
         - company_number
         - action
+        - delta_at

--- a/apispec/officer-delete-delta-spec.yml
+++ b/apispec/officer-delete-delta-spec.yml
@@ -37,3 +37,4 @@ components:
         - internal_id
         - company_number
         - action
+        - delta_at

--- a/apispec/psc-delete-delta-spec.yml
+++ b/apispec/psc-delete-delta-spec.yml
@@ -34,3 +34,4 @@ components:
       required:
         - company_number
         - action
+        - delta_at

--- a/apispec/psc-exemption-delete-delta-spec.yml
+++ b/apispec/psc-exemption-delete-delta-spec.yml
@@ -34,3 +34,4 @@ components:
       required:
         - company_number
         - action
+        - delta_at

--- a/apispec/psc-statement-delete-delta-spec.yml
+++ b/apispec/psc-statement-delete-delta-spec.yml
@@ -35,3 +35,4 @@ components:
         - company_number
         - psc_statement_id
         - action
+        - delta_at

--- a/apispec/registers-delete-delta-spec.yml
+++ b/apispec/registers-delete-delta-spec.yml
@@ -32,4 +32,3 @@ components:
       required:
         - company_number
         - action
-        - delta_at

--- a/apispec/registers-delete-delta-spec.yml
+++ b/apispec/registers-delete-delta-spec.yml
@@ -32,3 +32,4 @@ components:
       required:
         - company_number
         - action
+        - delta_at

--- a/validation/schema_testing/company/request_bodies/delete_bad_request_body.json
+++ b/validation/schema_testing/company/request_bodies/delete_bad_request_body.json
@@ -1,3 +1,4 @@
 {
-  "action": "DELETE"
+  "action": "DELETE",
+  "delta_at": "delta_at"
 }

--- a/validation/schema_testing/filinghistory/response_bodies/missing_required_fields_delete_response.json
+++ b/validation/schema_testing/filinghistory/response_bodies/missing_required_fields_delete_response.json
@@ -16,5 +16,14 @@
     "location": "action",
     "location_type": "json-path",
     "type": "ch:validation"
+  },
+  {
+    "error": "property 'delta_at' is missing",
+    "error_values": {
+      "action": ""
+    },
+    "location": "delta_at",
+    "location_type": "json-path",
+    "type": "ch:validation"
   }
 ]


### PR DESCRIPTION
This PR makes delta_at required on delete deltas except registers which does not have delete deltas set up in CHIPS.

[DSND-3109](https://companieshouse.atlassian.net/browse/DSND-3109)

[DSND-3109]: https://companieshouse.atlassian.net/browse/DSND-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ