### PR TITLE
DSND-3119: Add corporate_ind to delete delta

### DIFF
--- a/apispec/disqualification-delete-delta-spec.yml
+++ b/apispec/disqualification-delete-delta-spec.yml
@@ -31,6 +31,8 @@ components:
             - DELETE
         delta_at:
           type: string
+        corporate_ind:
+          type: string
       required:
         - officer_id
         - action

--- a/validation/schema_testing/disqualifications/request_bodies/delete_request_body
+++ b/validation/schema_testing/disqualifications/request_bodies/delete_request_body
@@ -1,5 +1,6 @@
 {
     "officer_id": "1234567",
     "action": "DELETE",
-    "delta_at": "string"
+    "delta_at": "string",
+    "corporate_ind": "1"
 }


### PR DESCRIPTION
This PR adds `corporate_ind` field to the dsq delete delta spec.

[DSND-3119](https://companieshouse.atlassian.net/browse/DSND-3119)

[DSND-3119]: https://companieshouse.atlassian.net/browse/DSND-3119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ