### PR TITLE
DSND-3113: Add internal_id as required to psc delete delta spec (strict)

### DIFF
--- a/apispec/psc-delete-delta-spec.yml
+++ b/apispec/psc-delete-delta-spec.yml
@@ -21,6 +21,8 @@ components:
     PscDeleteDelta:
       type: object
       properties:
+        internal_id:
+          type: string
         company_number:
           type: string
         psc_id:
@@ -43,6 +45,7 @@ components:
             - 'legal-person-beneficial-owner'
             - 'super-secure-beneficial-owner'
       required:
+        - internal_id
         - company_number
         - action
         - delta_at

--- a/validation/schema_testing/pscs/request_bodies/delete_ok_request_body
+++ b/validation/schema_testing/pscs/request_bodies/delete_ok_request_body
@@ -1,4 +1,5 @@
 {
+  "internal_id":"5",
   "company_number": "1234",
   "psc_id": "123456789",
   "action": "DELETE",

--- a/validation/schema_testing/pscs/response_bodies/delete_error_response_body
+++ b/validation/schema_testing/pscs/response_bodies/delete_error_response_body
@@ -1,5 +1,11 @@
 [
     {
+        "error":"property 'internal_id' is missing",
+        "error_values":{"internal_id":""},
+        "location":"internal_id",
+        "location_type":"json-path","type":"ch:validation"
+    },
+    {
         "error":"property 'company_number' is missing",
         "error_values":{"company_number":""},
         "location":"company_number",


### PR DESCRIPTION
* adds internal_id as required on the psc delta spec as needed by psc delta api to perform deletes
* makes chs-delta-api consistent with private specifications
* tested locally, works as expected. 
* Also tested via triggering psc delete deltas on staging and cidev, both contain delete deltas. 

[DSND-3113](https://companieshouse.atlassian.net/browse/DSND-3113)

[DSND-3113]: https://companieshouse.atlassian.net/browse/DSND-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ