### PR TITLE
DSND-3113: Add kind as required to psc delete delta spec (strict)

### DIFF
--- a/apispec/psc-delete-delta-spec.yml
+++ b/apispec/psc-delete-delta-spec.yml
@@ -49,3 +49,4 @@ components:
         - company_number
         - action
         - delta_at
+        - kind

--- a/validation/schema_testing/pscs/request_bodies/delete_bad_request_body
+++ b/validation/schema_testing/pscs/request_bodies/delete_bad_request_body
@@ -1,6 +1,5 @@
 {
   "psc_id": "123456789",
   "action": "DELETE",
-  "kind": "individual",
   "delta_at": "string"
 }

--- a/validation/schema_testing/pscs/response_bodies/delete_error_response_body
+++ b/validation/schema_testing/pscs/response_bodies/delete_error_response_body
@@ -10,5 +10,11 @@
         "error_values":{"company_number":""},
         "location":"company_number",
         "location_type":"json-path","type":"ch:validation"
+    },
+    {
+        "error":"property 'kind' is missing",
+        "error_values":{"kind":""},
+        "location":"kind",
+        "location_type":"json-path","type":"ch:validation"
     }
 ]


### PR DESCRIPTION
* adds kind as required on the psc delta spec as needed by psc delta api to post correct messages to the stream
* makes chs-delta-api consistent with private specifications

[DSND-3113](https://companieshouse.atlassian.net/browse/DSND-3113)

[DSND-3113]: https://companieshouse.atlassian.net/browse/DSND-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ