### PR TITLE
adding  bypass logic as migrated service to ECS

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -91,4 +91,6 @@ module "ecs-service" {
   eric_port                 = local.eric_port
   eric_environment_filename = local.eric_environment_filename
   eric_secrets              = local.eric_secrets
+  eric_extra_bypass_paths   = "/delta/document-store"
 }
+


### PR DESCRIPTION
since migration of service to ECS there was an issue as it now sits behind Eric which CHIPS does not support at present.
adding bypass logic so that it allows those requests through with the eric bypass paths option set on that specific path.